### PR TITLE
LPS-72585

### DIFF
--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -79,7 +79,7 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 				</div>
 			</c:when>
 			<c:otherwise>
-				<aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_password" %>' method="post" name="fm">
+				<aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_password" %>' method="post" id="update-password-fm" name="update-password-fm">
 					<aui:input name="p_l_id" type="hidden" value="<%= layout.getPlid() %>" />
 					<aui:input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 					<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
@@ -88,7 +88,6 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 					<aui:input name="ticketKey" type="hidden" value="<%= ticketKey %>" />
 
 					<c:if test="<%= !SessionErrors.isEmpty(request) %>">
-						<div class="alert alert-danger">
 							<c:choose>
 								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustBeLonger.class.getName()) %>">
 
@@ -96,7 +95,30 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 									UserPasswordException.MustBeLonger upe = (UserPasswordException.MustBeLonger)SessionErrors.get(request, UserPasswordException.MustBeLonger.class.getName());
 									%>
 
-									<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />
+									<aui:script use="liferay-form">
+										var form = Liferay.Form.get('<portlet:namespace />update-password-fm');
+
+										var oldFieldRules = form.get('fieldRules');
+
+										var newFieldRules = [
+											{
+											body: function(val, fieldNode, ruleValue) {
+												return false;
+											},
+											custom: true,
+											fieldName: '<portlet:namespace />password1',
+											validatorName: 'password-too-short',
+											errorMessage: '<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />'
+										}
+										];
+
+										var fieldRules = oldFieldRules.concat(newFieldRules);
+
+										form.set('fieldRules', fieldRules);
+
+
+									</aui:script>
+
 								</c:when>
 								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithModelListeners.class.getName()) %>">
 									<liferay-ui:message key="that-password-is-invalid-please-enter-a-different-password" />
@@ -131,7 +153,6 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 									<liferay-ui:message key="your-request-failed-to-complete" />
 								</c:otherwise>
 							</c:choose>
-						</div>
 					</c:if>
 
 					<aui:fieldset>

--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -107,49 +107,19 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 				</aui:form>
 
 				<c:if test="<%= !SessionErrors.isEmpty(request) %>">
+						
+					<aui:script use="liferay-form">
+
+					var validationErrors = [];
 						<c:choose>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustBeLonger.class.getName()) %>">
 								<%
 								UserPasswordException.MustBeLonger upe = (UserPasswordException.MustBeLonger)SessionErrors.get(request, UserPasswordException.MustBeLonger.class.getName());
 								%>
-
-								<aui:script use="liferay-form">
-									var form = Liferay.Form.get('<portlet:namespace />update-password-fm');
-
-									var thatPasswordIsTooShort = '<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />';
-
-									var oldFieldRules = form.get('fieldRules');
-
-									var newFieldRules = [];
-
-									if (thatPasswordIsTooShort.length > 0) {
-
-										newFieldRules.push(
-												{
-													body: function(val, fieldNode, ruleValue) {
-														console.log('!!!! Validation triggered');
-														return true;
-													},
-													custom: false,
-													fieldName: '<portlet:namespace />password1',
-													validatorName: 'required',
-													errorMessage: thatPasswordIsTooShort
-												}
-											);
-									}
-
-									var fieldRules = oldFieldRules.concat(newFieldRules);
-
-									form.set('fieldRules', fieldRules);
-
-									var formValidator = form.formValidator;
-                					formValidator.validateField('<portlet:namespace />password1');
-
-								</aui:script>
-
+								validationErrors.push('<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithModelListeners.class.getName()) %>">
-								<liferay-ui:message key="that-password-is-invalid-please-enter-a-different-password" />
+								validationErrors.push('<liferay-ui:message key="that-password-is-invalid-please-enter-a-different-password" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithRegex.class.getName()) %>">
 
@@ -157,30 +127,63 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 								UserPasswordException.MustComplyWithRegex upe = (UserPasswordException.MustComplyWithRegex)SessionErrors.get(request, UserPasswordException.MustComplyWithRegex.class.getName());
 								%>
 
-								<liferay-ui:message arguments="<%= upe.regex %>" key="that-password-does-not-comply-with-the-regular-expression" translateArguments="<%= false %>" />
+								validationErrors.push('<liferay-ui:message arguments="<%= upe.regex %>" key="that-password-does-not-comply-with-the-regular-expression" translateArguments="<%= false %>" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustMatch.class.getName()) %>">
-								<liferay-ui:message key="the-passwords-you-entered-do-not-match" />
+								validationErrors.push('<liferay-ui:message key="the-passwords-you-entered-do-not-match" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeEqualToCurrent.class.getName()) %>">
-								<liferay-ui:message key="your-new-password-cannot-be-the-same-as-your-old-password-please-enter-a-different-password" />
+								validationErrors.push('<liferay-ui:message key="your-new-password-cannot-be-the-same-as-your-old-password-please-enter-a-different-password" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeNull.class.getName()) %>">
-								<liferay-ui:message key="the-password-cannot-be-blank" />
+								validationErrors.push('<liferay-ui:message key="the-password-cannot-be-blank" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeRecentlyUsed.class.getName()) %>">
-								<liferay-ui:message key="that-password-has-already-been-used-please-enter-a-different-password" />
+								validationErrors.push('<liferay-ui:message key="that-password-has-already-been-used-please-enter-a-different-password" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeTrivial.class.getName()) %>">
-								<liferay-ui:message key="that-password-uses-common-words-please-enter-a-password-that-is-harder-to-guess-i-e-contains-a-mix-of-numbers-and-letters" />
+								validationErrors.push('<liferay-ui:message key="that-password-uses-common-words-please-enter-a-password-that-is-harder-to-guess-i-e-contains-a-mix-of-numbers-and-letters" />');
 							</c:when>
 							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotContainDictionaryWords.class.getName()) %>">
-								<liferay-ui:message key="that-password-uses-common-dictionary-words" />
+								validationErrors.push('<liferay-ui:message key="that-password-uses-common-dictionary-words" />');
 							</c:when>
 							<c:otherwise>
-								<liferay-ui:message key="your-request-failed-to-complete" />
+								<div class="alert alert-danger">
+									<liferay-ui:message key="your-request-failed-to-complete" />
+								</div>
 							</c:otherwise>
 						</c:choose>
+
+						var form = Liferay.Form.get('<portlet:namespace />update-password-fm');
+
+						var oldFieldRules = form.get('fieldRules');
+
+						var newFieldRules = [];
+
+						if (validationErrors.length > 0) {
+
+							newFieldRules.push(
+									{
+										body: function(val, fieldNode, ruleValue) {
+											console.log('!!!! Validation triggered');
+											return true;
+										},
+										custom: false,
+										fieldName: '<portlet:namespace />password1',
+										validatorName: 'required',
+										errorMessage: validationErrors.join(' ')
+									}
+								);
+						}
+
+						var fieldRules = oldFieldRules.concat(newFieldRules);
+
+						form.set('fieldRules', fieldRules);
+
+						var formValidator = form.formValidator;
+    					formValidator.validateField('<portlet:namespace />password1');
+
+					</aui:script>
 				</c:if>
 
 			</c:otherwise>

--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -79,81 +79,13 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 				</div>
 			</c:when>
 			<c:otherwise>
-				<aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_password" %>' method="post" id="update-password-fm" name="update-password-fm">
+				<aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_password" %>' method="post" name="update-password-fm">
 					<aui:input name="p_l_id" type="hidden" value="<%= layout.getPlid() %>" />
 					<aui:input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 					<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
 					<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 					<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value="<%= referer %>" />
 					<aui:input name="ticketKey" type="hidden" value="<%= ticketKey %>" />
-
-					<c:if test="<%= !SessionErrors.isEmpty(request) %>">
-							<c:choose>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustBeLonger.class.getName()) %>">
-
-									<%
-									UserPasswordException.MustBeLonger upe = (UserPasswordException.MustBeLonger)SessionErrors.get(request, UserPasswordException.MustBeLonger.class.getName());
-									%>
-
-									<aui:script use="liferay-form">
-										var form = Liferay.Form.get('<portlet:namespace />update-password-fm');
-
-										var oldFieldRules = form.get('fieldRules');
-
-										var newFieldRules = [
-											{
-											body: function(val, fieldNode, ruleValue) {
-												return false;
-											},
-											custom: true,
-											fieldName: '<portlet:namespace />password1',
-											validatorName: 'password-too-short',
-											errorMessage: '<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />'
-										}
-										];
-
-										var fieldRules = oldFieldRules.concat(newFieldRules);
-
-										form.set('fieldRules', fieldRules);
-
-
-									</aui:script>
-
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithModelListeners.class.getName()) %>">
-									<liferay-ui:message key="that-password-is-invalid-please-enter-a-different-password" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithRegex.class.getName()) %>">
-
-									<%
-									UserPasswordException.MustComplyWithRegex upe = (UserPasswordException.MustComplyWithRegex)SessionErrors.get(request, UserPasswordException.MustComplyWithRegex.class.getName());
-									%>
-
-									<liferay-ui:message arguments="<%= upe.regex %>" key="that-password-does-not-comply-with-the-regular-expression" translateArguments="<%= false %>" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustMatch.class.getName()) %>">
-									<liferay-ui:message key="the-passwords-you-entered-do-not-match" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeEqualToCurrent.class.getName()) %>">
-									<liferay-ui:message key="your-new-password-cannot-be-the-same-as-your-old-password-please-enter-a-different-password" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeNull.class.getName()) %>">
-									<liferay-ui:message key="the-password-cannot-be-blank" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeRecentlyUsed.class.getName()) %>">
-									<liferay-ui:message key="that-password-has-already-been-used-please-enter-a-different-password" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeTrivial.class.getName()) %>">
-									<liferay-ui:message key="that-password-uses-common-words-please-enter-a-password-that-is-harder-to-guess-i-e-contains-a-mix-of-numbers-and-letters" />
-								</c:when>
-								<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotContainDictionaryWords.class.getName()) %>">
-									<liferay-ui:message key="that-password-uses-common-dictionary-words" />
-								</c:when>
-								<c:otherwise>
-									<liferay-ui:message key="your-request-failed-to-complete" />
-								</c:otherwise>
-							</c:choose>
-					</c:if>
 
 					<aui:fieldset>
 						<aui:input autoFocus="<%= true %>" class="lfr-input-text-container" label="password" name="password1" showRequiredLabel="<%= false %>" type="password">
@@ -173,6 +105,84 @@ if (referer.startsWith(themeDisplay.getPathMain() + "/portal/update_password") &
 						<aui:button type="submit" />
 					</aui:button-row>
 				</aui:form>
+
+				<c:if test="<%= !SessionErrors.isEmpty(request) %>">
+						<c:choose>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustBeLonger.class.getName()) %>">
+								<%
+								UserPasswordException.MustBeLonger upe = (UserPasswordException.MustBeLonger)SessionErrors.get(request, UserPasswordException.MustBeLonger.class.getName());
+								%>
+
+								<aui:script use="liferay-form">
+									var form = Liferay.Form.get('<portlet:namespace />update-password-fm');
+
+									var thatPasswordIsTooShort = '<liferay-ui:message arguments="<%= String.valueOf(upe.minLength) %>" key="that-password-is-too-short" translateArguments="<%= false %>" />';
+
+									var oldFieldRules = form.get('fieldRules');
+
+									var newFieldRules = [];
+
+									if (thatPasswordIsTooShort.length > 0) {
+
+										newFieldRules.push(
+												{
+													body: function(val, fieldNode, ruleValue) {
+														console.log('!!!! Validation triggered');
+														return true;
+													},
+													custom: false,
+													fieldName: '<portlet:namespace />password1',
+													validatorName: 'required',
+													errorMessage: thatPasswordIsTooShort
+												}
+											);
+									}
+
+									var fieldRules = oldFieldRules.concat(newFieldRules);
+
+									form.set('fieldRules', fieldRules);
+
+									var formValidator = form.formValidator;
+                					formValidator.validateField('<portlet:namespace />password1');
+
+								</aui:script>
+
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithModelListeners.class.getName()) %>">
+								<liferay-ui:message key="that-password-is-invalid-please-enter-a-different-password" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustComplyWithRegex.class.getName()) %>">
+
+								<%
+								UserPasswordException.MustComplyWithRegex upe = (UserPasswordException.MustComplyWithRegex)SessionErrors.get(request, UserPasswordException.MustComplyWithRegex.class.getName());
+								%>
+
+								<liferay-ui:message arguments="<%= upe.regex %>" key="that-password-does-not-comply-with-the-regular-expression" translateArguments="<%= false %>" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustMatch.class.getName()) %>">
+								<liferay-ui:message key="the-passwords-you-entered-do-not-match" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeEqualToCurrent.class.getName()) %>">
+								<liferay-ui:message key="your-new-password-cannot-be-the-same-as-your-old-password-please-enter-a-different-password" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeNull.class.getName()) %>">
+								<liferay-ui:message key="the-password-cannot-be-blank" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeRecentlyUsed.class.getName()) %>">
+								<liferay-ui:message key="that-password-has-already-been-used-please-enter-a-different-password" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotBeTrivial.class.getName()) %>">
+								<liferay-ui:message key="that-password-uses-common-words-please-enter-a-password-that-is-harder-to-guess-i-e-contains-a-mix-of-numbers-and-letters" />
+							</c:when>
+							<c:when test="<%= SessionErrors.contains(request, UserPasswordException.MustNotContainDictionaryWords.class.getName()) %>">
+								<liferay-ui:message key="that-password-uses-common-dictionary-words" />
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:message key="your-request-failed-to-complete" />
+							</c:otherwise>
+						</c:choose>
+				</c:if>
+
 			</c:otherwise>
 		</c:choose>
 	</div>


### PR DESCRIPTION
Hi Marta. Here's a working example which converts all the server side validation errors into a single client side one. The approach I took was to override the 'required' validator (hence custom = false) so that if there are no server side errors it falls back to standard logic for that.

It's still possible to have both fields show a validation error. I'm not entirely convinced they necessary are asking for only one to show at a time. I think the AUI forms framework should be left to do its thing there. (something for the frontend guys to consider maybe)