### PR TITLE
OAUTH2-282 Give opportunity to the default ScopeDescriptor also

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScope.java
@@ -28,6 +28,10 @@ public class SAPEntryScope {
 		_scope = scope;
 	}
 
+	public SAPEntry getSapEntry() {
+		return _sapEntry;
+	}
+
 	public String getSapEntryName() {
 		return _sapEntry.getName();
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Tomas Polesovsky
@@ -38,17 +39,16 @@ public class SAPEntryScopeDescriptorFinder
 			SAPEntry sapEntry = sapEntryScope.getSapEntry();
 
 			if (sapEntry.isEnabled()) {
-				_sapEntryScopes.put(sapEntryScope.getScope(), sapEntryScope);
+				_scopes.add(sapEntryScope.getScope());
 			}
 
-			_sapEntryScopesDescriptors.put(
-				sapEntryScope.getScope(), sapEntryScope);
+			_sapEntryScopes.put(sapEntryScope.getScope(), sapEntryScope);
 		}
 	}
 
 	@Override
 	public String describeScope(String scope, Locale locale) {
-		SAPEntryScope sapEntryScope = _sapEntryScopesDescriptors.get(scope);
+		SAPEntryScope sapEntryScope = _sapEntryScopes.get(scope);
 
 		if (sapEntryScope == null) {
 			if (_log.isDebugEnabled()) {
@@ -63,14 +63,13 @@ public class SAPEntryScopeDescriptorFinder
 
 	@Override
 	public Collection<String> findScopes() {
-		return new HashSet<>(_sapEntryScopes.keySet());
+		return new HashSet<>(_scopes);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SAPEntryScopeDescriptorFinder.class);
 
 	private final Map<String, SAPEntryScope> _sapEntryScopes = new HashMap<>();
-	private final Map<String, SAPEntryScope> _sapEntryScopesDescriptors =
-		new HashMap<>();
+	private final Set<String> _scopes = new HashSet<>();
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
@@ -55,7 +55,7 @@ public class SAPEntryScopeDescriptorFinder
 				_log.warn("Unable to get SAP entry scope " + scope);
 			}
 
-			return scope;
+			return null;
 		}
 
 		return sapEntryScope.getTitle(locale);

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
@@ -51,8 +51,8 @@ public class SAPEntryScopeDescriptorFinder
 		SAPEntryScope sapEntryScope = _sapEntryScopesDescriptors.get(scope);
 
 		if (sapEntryScope == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to get SAP entry scope " + scope);
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get SAP entry scope " + scope);
 			}
 
 			return null;

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinder.java
@@ -16,9 +16,9 @@ package com.liferay.oauth2.provider.jsonws.internal.service.access.policy.scope;
 
 import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,20 +35,27 @@ public class SAPEntryScopeDescriptorFinder
 
 	public SAPEntryScopeDescriptorFinder(List<SAPEntryScope> sapEntryScopes) {
 		for (SAPEntryScope sapEntryScope : sapEntryScopes) {
-			_sapEntryScopes.put(sapEntryScope.getScope(), sapEntryScope);
+			SAPEntry sapEntry = sapEntryScope.getSapEntry();
+
+			if (sapEntry.isEnabled()) {
+				_sapEntryScopes.put(sapEntryScope.getScope(), sapEntryScope);
+			}
+
+			_sapEntryScopesDescriptors.put(
+				sapEntryScope.getScope(), sapEntryScope);
 		}
 	}
 
 	@Override
 	public String describeScope(String scope, Locale locale) {
-		SAPEntryScope sapEntryScope = _sapEntryScopes.get(scope);
+		SAPEntryScope sapEntryScope = _sapEntryScopesDescriptors.get(scope);
 
 		if (sapEntryScope == null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn("Unable to get SAP entry scope " + scope);
 			}
 
-			return StringPool.BLANK;
+			return scope;
 		}
 
 		return sapEntryScope.getTitle(locale);
@@ -63,5 +70,7 @@ public class SAPEntryScopeDescriptorFinder
 		SAPEntryScopeDescriptorFinder.class);
 
 	private final Map<String, SAPEntryScope> _sapEntryScopes = new HashMap<>();
+	private final Map<String, SAPEntryScope> _sapEntryScopesDescriptors =
+		new HashMap<>();
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinderRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinderRegistrator.java
@@ -189,8 +189,6 @@ public class SAPEntryScopeDescriptorFinderRegistrator {
 
 		return stream.filter(
 			this::isOAuth2ExportedSAPEntry
-		).filter(
-			SAPEntry::isEnabled
 		).map(
 			sapEntry -> new SAPEntryScope(sapEntry, _parseScope(sapEntry))
 		).collect(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
@@ -19,6 +19,7 @@ import com.liferay.oauth2.provider.scope.liferay.ScopeDescriptorLocator;
 import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -36,6 +37,12 @@ public class ScopeDescriptorLocatorImpl implements ScopeDescriptorLocator {
 	public ScopeDescriptor getScopeDescriptor(String applicationName) {
 		ScopeDescriptor scopeDescriptor =
 			_scopeDescriptorsByApplicationName.getService(applicationName);
+
+		if ((_defaultScopeDescriptor != null) && (scopeDescriptor != null)) {
+			return (scope, locale) -> GetterUtil.getString(
+				scopeDescriptor.describeScope(scope, locale),
+				_defaultScopeDescriptor.describeScope(scope, locale));
+		}
 
 		if (scopeDescriptor == null) {
 			return _defaultScopeDescriptor;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/scope/descriptor/ScopeDescriptorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/scope/descriptor/ScopeDescriptorImpl.java
@@ -40,7 +40,7 @@ public class ScopeDescriptorImpl implements ScopeDescriptor {
 			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return GetterUtil.getString(
-			ResourceBundleUtil.getString(resourceBundle, key), scope);
+			ResourceBundleUtil.getString(resourceBundle, key), key);
 	}
 
 	@Reference(


### PR DESCRIPTION
Hi Marta. I've made some minor changes to the SAPEntryDiscriptorFinder and scope-impl module to enable the "default=true" ScopeDescriptor to describe deleted SAP scopes.

At the time we originally designed this we didn't expect this to be needed, but now we are highlighting the assigned scopes that are no longer available.

With this change, admins can simply add the deleted SAP based scopes to a module that uses the "Language Extender" feature to add to the scope-impl default translations. Should be a nice generalized approach.

p.s. this is only for deleted SAP entries. Disabled ones work as we agreed in chat.

/cc @csierra