### PR TITLE
OAUTH2-292 Still send previously assigned scope alias when unavailable + selected

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
@@ -63,9 +63,11 @@
 							data.put("slave", globalScopeAliasesString);
 
 							String id = "scopeAlias" + StringUtil.randomId();
+
+							boolean removedScope = scopeAliases.isEmpty() && globalScopeAliases.isEmpty();
 						%>
 
-							<li class="list-group-item list-group-item-flex<c:if test="<%= scopeAliases.isEmpty() && globalScopeAliases.isEmpty() %>"> removed-scope</c:if>">
+							<li class="list-group-item list-group-item-flex<c:if test="<%= removedScope %>"> removed-scope</c:if>">
 								<div class="autofit-col">
 									<c:choose>
 										<c:when test="<%= assignedScopeAliases.isEmpty() && scopeAliases.isEmpty() %>">
@@ -75,6 +77,10 @@
 
 											<%
 											String scopeAliasesString = StringUtil.merge(scopeAliases, StringPool.SPACE);
+
+											if (removedScope) {
+												scopeAliasesString = "removed-scope";
+											}
 											%>
 
 											<aui:input checked="<%= !assignedScopeAliases.isEmpty() %>" data="<%= data %>" id="<%= id %>" label="" name="scopeAliases" onChange='<%= renderResponse.getNamespace() + "recalculateDependants(this)" %>' title="<%= scopeAliasesString %>" type="checkbox" value="<%= scopeAliasesString %>" />

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
@@ -76,10 +76,13 @@
 										<c:otherwise>
 
 											<%
-											String scopeAliasesString = StringUtil.merge(scopeAliases, StringPool.SPACE);
+											String scopeAliasesString;
 
 											if (removedScope) {
-												scopeAliasesString = "removed-scope";
+												scopeAliasesString = StringUtil.merge(assignedScopeAliases, StringPool.SPACE);
+											}
+											else {
+												scopeAliasesString = StringUtil.merge(scopeAliases, StringPool.SPACE);
 											}
 											%>
 


### PR DESCRIPTION
Hi Marta. I think it is better to send the original scope alias because we may want to take some actions on the backend in the future. Better that sending "removed-scope" which might actually be a real thing :)