### PR TITLE
LPS-102662 Conflate empty client_secret with no client_secret

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
@@ -56,6 +56,18 @@ public class LiferayAccessTokenService extends AccessTokenService {
 	protected Client authenticateClientIfNeeded(
 		MultivaluedMap<String, String> params) {
 
+		String clientId = params.getFirst("client_id");
+
+		if ((clientId != null) && clientId.isEmpty()) {
+			reportInvalidClient();
+		}
+
+		String clientSecret = params.getFirst("client_secret");
+
+		if ((clientSecret != null) && clientSecret.isEmpty()) {
+			params.remove("client_secret");
+		}
+
 		Client client = super.authenticateClientIfNeeded(params);
 
 		Map<String, String> properties = client.getProperties();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -73,10 +73,9 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 						"liferay.LiferayOAuthDataProvider",
 					Level.WARN)) {
 
-			String errorString = parseError(
-				invocationBuilder.post(Entity.form(formData)));
+			Response response = invocationBuilder.post(Entity.form(formData));
 
-			Assert.assertEquals("invalid_client", errorString);
+			Assert.assertEquals(401, response.getStatus());
 
 			formData = new MultivaluedHashMap<>();
 
@@ -84,7 +83,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 			formData.add("client_secret", "wrong");
 			formData.add("grant_type", "client_credentials");
 
-			errorString = parseError(
+			String errorString = parseError(
 				invocationBuilder.post(Entity.form(formData)));
 
 			Assert.assertEquals("invalid_client", errorString);
@@ -95,10 +94,9 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 			formData.add("client_secret", "");
 			formData.add("grant_type", "client_credentials");
 
-			errorString = parseError(
-				invocationBuilder.post(Entity.form(formData)));
+			response = invocationBuilder.post(Entity.form(formData));
 
-			Assert.assertEquals("invalid_client", errorString);
+			Assert.assertEquals(401, response.getStatus());
 
 			formData = new MultivaluedHashMap<>();
 


### PR DESCRIPTION
/cc @stian-sigvartsen

hey... I have made some changes to conflate the case of empty `client_secret` with no `client_secret` sent, like the spec seems to suggest. 
Per the tests we treated that before like an invalid client. With this change it just fails to authenticate the client which might be what we want. This should work for clients which have no secret.

Carlos.