### PR TITLE
LPS-106919 Allow matching of root resources with wildcard

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-verifier-test/src/testIntegration/java/com/liferay/portal/security/auth/verifier/test/AuthVerifierTest.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier-test/src/testIntegration/java/com/liferay/portal/security/auth/verifier/test/AuthVerifierTest.java
@@ -409,6 +409,19 @@ public class AuthVerifierTest {
 		}
 	}
 
+	@Test
+	public void testServletContextRootResourceMatchedByWildcard()
+		throws Exception {
+
+		URL url = new URL(
+			"http://localhost:8080/o" +
+				"/auth-verifier-filter-override-matched-test");
+
+		try (InputStream inputStream = url.openStream()) {
+			Assert.assertEquals("matched", StringUtil.read(inputStream));
+		}
+	}
+
 	public static class AuthVerifierMatchedHttpServlet extends HttpServlet {
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -118,13 +118,11 @@ public class AuthVerifierPipeline {
 
 		String contextPath = httpServletRequest.getContextPath();
 
-		requestURI = requestURI.substring(contextPath.length());
-
 		for (AuthVerifierConfiguration authVerifierConfiguration :
 				_authVerifierConfigurations) {
 
 			authVerifierConfiguration = _mergeAuthVerifierConfiguration(
-				authVerifierConfiguration, accessControlContext);
+				authVerifierConfiguration, accessControlContext, contextPath);
 
 			if (_isMatchingRequestURI(authVerifierConfiguration, requestURI)) {
 				authVerifierConfigurations.add(authVerifierConfiguration);
@@ -165,7 +163,7 @@ public class AuthVerifierPipeline {
 
 	private AuthVerifierConfiguration _mergeAuthVerifierConfiguration(
 		AuthVerifierConfiguration authVerifierConfiguration,
-		AccessControlContext accessControlContext) {
+		AccessControlContext accessControlContext, String contextPath) {
 
 		Map<String, Object> settings = accessControlContext.getSettings();
 
@@ -211,8 +209,22 @@ public class AuthVerifierPipeline {
 					String propertiesKey = settingsKey.substring(
 						authVerifierSettingsKey.length());
 
-					mergedProperties.setProperty(
-						propertiesKey, (String)settingsValue);
+					if (propertiesKey.equals("urls.includes") ||
+						propertiesKey.equals("urls.excludes")) {
+
+						String settingsValueString = (String)settingsValue;
+
+						if (settingsValueString.charAt(0) != '/') {
+							settingsValueString = "/" + settingsValueString;
+						}
+
+						mergedProperties.setProperty(
+							propertiesKey, contextPath + settingsValueString);
+					}
+					else {
+						mergedProperties.setProperty(
+							propertiesKey, (String)settingsValue);
+					}
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -118,6 +118,10 @@ public class AuthVerifierPipeline {
 
 		String contextPath = httpServletRequest.getContextPath();
 
+		if (requestURI.equals(contextPath)) {
+			requestURI += "/";
+		}
+
 		for (AuthVerifierConfiguration authVerifierConfiguration :
 				_authVerifierConfigurations) {
 


### PR DESCRIPTION
This fixes the regression detailed in [LPS-106919](https://issues.liferay.com/browse/LPS-106919).

I also include 5d20520dd which is to re-instate the fix for [LPS-102770](https://issues.liferay.com/browse/LPS-102770) which was reverted upstream because of the aforementioned regression it caused.

Additionally I include a suite of tests for LPS-102770 with 6555fc2

/cc  @csierra