### PR TITLE
LPS-113813

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.captcha.CaptchaException;
 import com.liferay.portal.kernel.captcha.CaptchaTextException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -487,6 +488,12 @@ public class SimpleCaptchaImpl implements Captcha {
 	private GimpyRenderer[] _gimpyRenderers;
 	private final Map<String, Object> _instances = new ConcurrentHashMap<>();
 	private NoiseProducer[] _noiseProducers;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.captcha.api)(release.schema.version>=1.1.0))"
+	)
+	private Release _release;
+
 	private TextProducer[] _textProducers;
 	private WordRenderer[] _wordRenderers;
 

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/constants/LegacyCaptchaPropsKeys.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/constants/LegacyCaptchaPropsKeys.java
@@ -42,6 +42,14 @@ public class LegacyCaptchaPropsKeys {
 			"nl.captcha.gimpy.BlockGimpyRenderer";
 
 	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_DROP_SHADOW_GYMPY_RENDERER_CLASS =
+			"com.liferay.captcha.simplecaptcha.gimpy.DropShadowGimpyRenderer";
+
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_DROP_SHADOW_GYMPY_RENDERER_DEPRECATED_CLASS =
+			"nl.captcha.gimpy.DropShadowGimpyRenderer";
+
+	public static final String
 		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_GIMPY_RENDERERS_PROPERTY =
 			"simpleCaptchaGimpyRenderers";
 

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/constants/LegacyCaptchaPropsKeys.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/constants/LegacyCaptchaPropsKeys.java
@@ -33,6 +33,26 @@ public class LegacyCaptchaPropsKeys {
 		CAPTCHA_CHECK_PORTLET_MESSAGE_BOARDS_EDIT_MESSAGE =
 			"captcha.check.portlet.message_boards.edit_message";
 
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_BLOCK_GYMPY_RENDERER_CLASS =
+			"com.liferay.captcha.simplecaptcha.gimpy.BlockGimpyRenderer";
+
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_BLOCK_GYMPY_RENDERER_DEPRECATED_CLASS =
+			"nl.captcha.gimpy.BlockGimpyRenderer";
+
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_GIMPY_RENDERERS_PROPERTY =
+			"simpleCaptchaGimpyRenderers";
+
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_CLASS =
+			"com.liferay.captcha.simplecaptcha.gimpy.RippleGimpyRenderer";
+
+	public static final String
+		CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_DEPRECATED_CLASS =
+			"nl.captcha.gimpy.RippleGimpyRenderer";
+
 	public static final String CAPTCHA_ENGINE_IMPL = "captcha.engine.impl";
 
 	public static final String CAPTCHA_ENGINE_RECAPTCHA_KEY_PRIVATE =

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/CaptchaUpgrade.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/CaptchaUpgrade.java
@@ -15,10 +15,12 @@
 package com.liferay.captcha.internal.upgrade;
 
 import com.liferay.captcha.internal.upgrade.v1_0_0.UpgradeCaptchaConfiguration;
+import com.liferay.captcha.internal.upgrade.v1_1_0.UpgradeCaptchaConfigurationPreferences;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -36,7 +38,14 @@ public class CaptchaUpgrade implements UpgradeStepRegistrator {
 			"0.0.1", "1.0.0",
 			new UpgradeCaptchaConfiguration(
 				_prefsPropsToConfigurationUpgradeHelper));
+
+		registry.register(
+			"1.0.0", "1.1.0",
+			new UpgradeCaptchaConfigurationPreferences(_configurationAdmin));
 	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
@@ -89,7 +89,7 @@ public class UpgradeCaptchaConfigurationPreferences extends UpgradeProcess {
 		Stream<String> stream = Arrays.stream(array);
 
 		return stream.map(
-			s -> s.replace(target, replacement)
+			s -> target.equals(s.trim()) ? replacement : s
 		).toArray(
 			size -> new String[size]
 		);

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
@@ -64,6 +64,13 @@ public class UpgradeCaptchaConfigurationPreferences extends UpgradeProcess {
 		upgradedSimpleCaptchaGimpyRenderers = _replaceArrayValue(
 			upgradedSimpleCaptchaGimpyRenderers,
 			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_DROP_SHADOW_GYMPY_RENDERER_DEPRECATED_CLASS,
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_DROP_SHADOW_GYMPY_RENDERER_CLASS);
+
+		upgradedSimpleCaptchaGimpyRenderers = _replaceArrayValue(
+			upgradedSimpleCaptchaGimpyRenderers,
+			LegacyCaptchaPropsKeys.
 				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_DEPRECATED_CLASS,
 			LegacyCaptchaPropsKeys.
 				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_CLASS);

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/v1_1_0/UpgradeCaptchaConfigurationPreferences.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.captcha.internal.upgrade.v1_1_0;
+
+import com.liferay.captcha.internal.constants.LegacyCaptchaPropsKeys;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.stream.Stream;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Marta Medio
+ */
+public class UpgradeCaptchaConfigurationPreferences extends UpgradeProcess {
+
+	public UpgradeCaptchaConfigurationPreferences(
+		ConfigurationAdmin configurationAdmin) {
+
+		_configurationAdmin = configurationAdmin;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			"com.liferay.captcha.configuration.CaptchaConfiguration",
+			StringPool.QUESTION);
+
+		Dictionary<String, Object> properties = configuration.getProperties();
+
+		if (properties == null) {
+			return;
+		}
+
+		String[] simpleCaptchaGimpyRenderers = GetterUtil.getStringValues(
+			properties.get(
+				LegacyCaptchaPropsKeys.
+					CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_GIMPY_RENDERERS_PROPERTY));
+
+		String[] upgradedSimpleCaptchaGimpyRenderers = _replaceArrayValue(
+			simpleCaptchaGimpyRenderers,
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_BLOCK_GYMPY_RENDERER_DEPRECATED_CLASS,
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_BLOCK_GYMPY_RENDERER_CLASS);
+
+		upgradedSimpleCaptchaGimpyRenderers = _replaceArrayValue(
+			upgradedSimpleCaptchaGimpyRenderers,
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_DEPRECATED_CLASS,
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_RIPPLE_GYMPY_RENDERER_CLASS);
+
+		properties.put(
+			LegacyCaptchaPropsKeys.
+				CAPTCHA_CONFIGURATION_SIMPLECAPTCHA_GIMPY_RENDERERS_PROPERTY,
+			upgradedSimpleCaptchaGimpyRenderers);
+
+		configuration.update(properties);
+	}
+
+	private String[] _replaceArrayValue(
+		String[] array, String target, String replacement) {
+
+		Stream<String> stream = Arrays.stream(array);
+
+		return stream.map(
+			s -> s.replace(target, replacement)
+		).toArray(
+			size -> new String[size]
+		);
+	}
+
+	private final ConfigurationAdmin _configurationAdmin;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113813

Hi @martamedio 

I have added two minor changes:

- https://github.com/martamedio/liferay-portal/pull/153/commits/d691e0739d48f92f9a74938a3a154780e580eb04 => We should also rewrite nl.captcha.gimpy.DropShadowGimpyRenderer as customers can being using it. That Gimpy Renderer was removed in LPS-65331 because NPE problems, but now it works after LPS-90046 changes
- https://github.com/martamedio/liferay-portal/pull/153/commits/4f8fb8b3ad11fc68e157a4c0aecfd83a54970e1b => I think it is better to compare the whole string instead of replacing. I have added a trim() because in current code, we are trimming the className before creating the object, see: https://github.com/liferay/liferay-portal/blob/39c5030e7d18fe2f3ee95db5b612b344c8ba0990/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java#L450

In your pull there is an error in the CI tests, see: https://github.com/jorgediaz-lr/liferay-portal/pull/282#issuecomment-645089127
```
junit.framework.AssertionFailedError: 
Declarative Service Unsatisfied Component Checker check result: 
Bundle {id: 319, name: com.liferay.captcha.api, version: 4.1.2}
	Declarative Service {id: 1074, name: com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl, unsatisfied references: 
		{name: _release, target: (&(release.bundle.symbolic.name=com.liferay.captcha.api)(release.schema.version>=1.1.0))}
	}
	Declarative Service {id: 1073, name: com.liferay.captcha.recaptcha.ReCaptchaImpl, unsatisfied references: 
		{name: _release, target: (&(release.bundle.symbolic.name=com.liferay.captcha.api)(release.schema.version>=1.1.0))}
	}
	at com.liferay.portal.log.assertor.PortalLogAssertorTest.scanXMLLogFile(PortalLogAssertorTest.java:171)
	at com.liferay.portal.log.assertor.PortalLogAssertorTest$1.visitFile(PortalLogAssertorTest.java:98)
	at com.liferay.portal.log.assertor.PortalLogAssertorTest$1.visitFile(PortalLogAssertorTest.java:88)
	at java.nio.file.Files.walkFileTree(Files.java:2670)
	at java.nio.file.Files.walkFileTree(Files.java:2742)
	at com.liferay.portal.log.assertor.PortalLogAssertorTest.testScanXMLLog(PortalLogAssertorTest.java:86)
```
I had a look to it but I don't know the root cause of the error