### PR TITLE
LPS-97485

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/CalendarResourceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/CalendarResourceUtil.java
@@ -94,6 +94,12 @@ public class CalendarResourceUtil {
 
 		Map<Locale, String> descriptionMap = new HashMap<>();
 
+		if (serviceContext != null) {
+			serviceContext = (ServiceContext)serviceContext.clone();
+
+			serviceContext.setModelPermissions(null);
+		}
+
 		return CalendarResourceLocalServiceUtil.addCalendarResource(
 			userId, groupId, PortalUtil.getClassNameId(Group.class), groupId,
 			null, null,
@@ -137,6 +143,12 @@ public class CalendarResourceUtil {
 		).build();
 
 		Map<Locale, String> descriptionMap = new HashMap<>();
+
+		if (serviceContext != null) {
+			serviceContext = (ServiceContext)serviceContext.clone();
+
+			serviceContext.setModelPermissions(null);
+		}
 
 		return CalendarResourceLocalServiceUtil.addCalendarResource(
 			userId, userGroup.getGroupId(),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
@@ -185,7 +185,8 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 		_viewCountEntryLocalService = viewCountEntryLocalService;
 
 		_dlFolderModelPermissions = ModelPermissionsFactory.create(
-			_DLFOLDER_GROUP_PERMISSIONS, _DLFOLDER_GUEST_PERMISSIONS);
+			_DLFOLDER_GROUP_PERMISSIONS, _DLFOLDER_GUEST_PERMISSIONS,
+			DLFolder.class.getName());
 
 		_dlFolderModelPermissions.addRolePermissions(
 			RoleConstants.OWNER, _DLFOLDER_OWNER_PERMISSIONS);
@@ -2284,10 +2285,11 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 			_entryVersion = entryVersion;
 			_entryModelName = entryModelName;
 
-			_modelPermissions = ModelPermissionsFactory.create(
-				_groupPermissions, _guestPermissions);
+			_dlFileEntryModelPermissions = ModelPermissionsFactory.create(
+				_groupPermissions, _guestPermissions,
+				DLFileEntry.class.getName());
 
-			_modelPermissions.addRolePermissions(
+			_dlFileEntryModelPermissions.addRolePermissions(
 				RoleConstants.OWNER, _ownerPermissions);
 		}
 
@@ -2693,7 +2695,8 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 
 				ServiceContext serviceContext = new ServiceContext();
 
-				serviceContext.setModelPermissions(_modelPermissions);
+				serviceContext.setModelPermissions(
+					_dlFileEntryModelPermissions);
 
 				_resourceLocalService.addModelResources(
 					dlFileEntry, serviceContext);
@@ -2729,13 +2732,13 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 
 		private final long _companyId;
 		private final Timestamp _createDate;
+		private final ModelPermissions _dlFileEntryModelPermissions;
 		private final long _entryId;
 		private final String _entryModelName;
 		private final String _entryVersion;
 		private final long _groupId;
 		private final String[] _groupPermissions = {"ADD_DISCUSSION", "VIEW"};
 		private final String[] _guestPermissions = {"ADD_DISCUSSION", "VIEW"};
-		private final ModelPermissions _modelPermissions;
 		private final Timestamp _now = new Timestamp(
 			System.currentTimeMillis());
 		private final String[] _ownerPermissions = {

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/util/MBUtil.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/util/MBUtil.java
@@ -68,7 +68,7 @@ public class MBUtil {
 			guestRole, roleIdsToActionIds);
 
 		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-			groupPermissions, guestPermissions);
+			groupPermissions, guestPermissions, MBMessage.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
@@ -121,7 +121,8 @@ public class MBMessageServiceTest {
 
 		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
 			new String[] {ActionKeys.ADD_MESSAGE, ActionKeys.VIEW},
-			new String[] {ActionKeys.ADD_MESSAGE, ActionKeys.VIEW});
+			new String[] {ActionKeys.ADD_MESSAGE, ActionKeys.VIEW},
+			MBCategory.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -167,7 +168,7 @@ public class PermissionFilterFacetedSearcherTest
 
 		serviceContext.setAddGuestPermissions(false);
 
-		ModelPermissions modelPermissions = new ModelPermissions();
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.OWNER, ActionKeys.VIEW);

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
@@ -168,7 +168,8 @@ public class PermissionFilterFacetedSearcherTest
 
 		serviceContext.setAddGuestPermissions(false);
 
-		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
+		ModelPermissions modelPermissions =
+			ModelPermissionsFactory.createForAllResources();
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.OWNER, ActionKeys.VIEW);

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -134,7 +135,7 @@ public class SearchPermissionCheckerFacetedSearcherTest
 	}
 
 	protected ModelPermissions createModelPermissions() {
-		ModelPermissions modelPermissions = new ModelPermissions();
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.OWNER, ActionKeys.VIEW);

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
@@ -135,7 +135,8 @@ public class SearchPermissionCheckerFacetedSearcherTest
 	}
 
 	protected ModelPermissions createModelPermissions() {
-		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
+		ModelPermissions modelPermissions =
+			ModelPermissionsFactory.createForAllResources();
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.OWNER, ActionKeys.VIEW);

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
@@ -526,6 +526,14 @@ public class SyncHelperImpl implements SyncHelper {
 					FileEntry.class.getName());
 			}
 		}
+		else {
+			if (folder) {
+				modelPermissions.setResourceName(Folder.class.getName());
+			}
+			else {
+				modelPermissions.setResourceName(FileEntry.class.getName());
+			}
+		}
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, resourceActions);

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.Digester;
@@ -516,7 +517,14 @@ public class SyncHelperImpl implements SyncHelper {
 			serviceContext.getModelPermissions();
 
 		if (modelPermissions == null) {
-			modelPermissions = new ModelPermissions();
+			if (folder) {
+				modelPermissions = ModelPermissionsFactory.create(
+					Folder.class.getName());
+			}
+			else {
+				modelPermissions = ModelPermissionsFactory.create(
+					FileEntry.class.getName());
+			}
 		}
 
 		modelPermissions.addRolePermissions(

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/test/TrashEntryLocalServiceCheckEntriesTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/test/TrashEntryLocalServiceCheckEntriesTest.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.trash.TrashHelper;
 import com.liferay.trash.model.TrashEntry;
 import com.liferay.trash.service.TrashEntryLocalServiceUtil;
@@ -81,7 +82,9 @@ public class TrashEntryLocalServiceCheckEntriesTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/DefinitionServiceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/DefinitionServiceTest.java
@@ -164,7 +164,7 @@ public class DefinitionServiceTest {
 			ServiceContextTestUtil.getServiceContext();
 
 		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-			_DEFINITION_GROUP_PERMISSIONS, null);
+			_DEFINITION_GROUP_PERMISSIONS, null, Definition.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 
@@ -185,7 +185,8 @@ public class DefinitionServiceTest {
 		}
 
 		modelPermissions = ModelPermissionsFactory.create(
-			_DEFINITION_GROUP_PERMISSIONS, new String[] {"VIEW"});
+			_DEFINITION_GROUP_PERMISSIONS, new String[] {"VIEW"},
+			Definition.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/EntryServiceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/EntryServiceTest.java
@@ -217,7 +217,7 @@ public class EntryServiceTest {
 			ServiceContextTestUtil.getServiceContext();
 
 		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-			_ENTRY_GROUP_PERMISSIONS, null);
+			_ENTRY_GROUP_PERMISSIONS, null, Entry.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 
@@ -232,7 +232,8 @@ public class EntryServiceTest {
 		}
 
 		modelPermissions = ModelPermissionsFactory.create(
-			_ENTRY_GROUP_PERMISSIONS, new String[] {"VIEW"});
+			_ENTRY_GROUP_PERMISSIONS, new String[] {"VIEW"},
+			Entry.class.getName());
 
 		serviceContext.setModelPermissions(modelPermissions);
 

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/SourceServiceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/SourceServiceTest.java
@@ -181,7 +181,7 @@ public class SourceServiceTest {
 				ServiceContextTestUtil.getServiceContext();
 
 			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-				_SOURCE_GROUP_PERMISSIONS, null);
+				_SOURCE_GROUP_PERMISSIONS, null, Source.class.getName());
 
 			serviceContext.setModelPermissions(modelPermissions);
 
@@ -197,7 +197,8 @@ public class SourceServiceTest {
 			}
 
 			modelPermissions = ModelPermissionsFactory.create(
-				_SOURCE_GROUP_PERMISSIONS, new String[] {"VIEW"});
+				_SOURCE_GROUP_PERMISSIONS, new String[] {"VIEW"},
+				Source.class.getName());
 
 			serviceContext.setModelPermissions(modelPermissions);
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/upgrade/v1_1_0/UpgradeKaleoProcess.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/upgrade/v1_1_0/UpgradeKaleoProcess.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -186,7 +187,7 @@ public class UpgradeKaleoProcess extends UpgradeProcess {
 			long companyId, String resourceName, long primKey)
 		throws PortalException {
 
-		ModelPermissions modelPermissions = new ModelPermissions();
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
 
 		List<ResourceAction> resourceActions =
 			_resourceActionLocalService.getResourceActions(resourceName);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/upgrade/v1_1_0/UpgradeKaleoProcess.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/upgrade/v1_1_0/UpgradeKaleoProcess.java
@@ -187,7 +187,8 @@ public class UpgradeKaleoProcess extends UpgradeProcess {
 			long companyId, String resourceName, long primKey)
 		throws PortalException {
 
-		ModelPermissions modelPermissions = ModelPermissionsFactory.create();
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
+			resourceName);
 
 		List<ResourceAction> resourceActions =
 			_resourceActionLocalService.getResourceActions(resourceName);

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1621,12 +1621,9 @@ public class ResourcePermissionLocalServiceImpl
 		for (String roleName : modelPermissions.getRoleNames()) {
 			Role role = getRole(companyId, groupId, roleName);
 
-			List<String> actionIds = modelPermissions.getActionIdsList(
-				roleName);
-
 			setResourcePermissions(
 				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				role.getRoleId(), actionIds.toArray(new String[0]));
+				role.getRoleId(), modelPermissions.getActionIds(roleName));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.internal.service.permission.ModelPermissionsImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.AuditedModel;
@@ -1979,7 +1980,7 @@ public class ResourcePermissionLocalServiceImpl
 		ModelPermissions modelPermissions, String resourcePermissionName) {
 
 		if ((modelPermissions == null) ||
-			ModelPermissions.RESOURCE_NAME_UNINITIALIZED.equals(
+			ModelPermissionsImpl.RESOURCE_NAME_UNINITIALIZED.equals(
 				modelPermissions.getResourceName())) {
 
 			if (_log.isDebugEnabled()) {
@@ -1992,7 +1993,7 @@ public class ResourcePermissionLocalServiceImpl
 			return false;
 		}
 
-		if (ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE.equals(
+		if (ModelPermissionsImpl.RESOURCE_NAME_FIRST_RESOURCE.equals(
 				modelPermissions.getResourceName())) {
 
 			if (!modelPermissions.isUsed()) {
@@ -2016,7 +2017,7 @@ public class ResourcePermissionLocalServiceImpl
 			return false;
 		}
 
-		if (ModelPermissions.RESOURCE_NAME_ALL_RESOURCES.equals(
+		if (ModelPermissionsImpl.RESOURCE_NAME_ALL_RESOURCES.equals(
 				modelPermissions.getResourceName())) {
 
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -169,29 +169,28 @@ public class ResourcePermissionLocalServiceImpl
 
 			// Owner permissions
 
-				Role ownerRole = roleLocalService.getRole(
-					companyId, RoleConstants.OWNER);
+			Role ownerRole = roleLocalService.getRole(
+				companyId, RoleConstants.OWNER);
 
-				List<String> ownerActionIds =
-					ResourceActionsUtil.getModelResourceActions(name);
+			List<String> ownerActionIds =
+				ResourceActionsUtil.getModelResourceActions(name);
 
-				filterOwnerActions(name, ownerActionIds);
+			filterOwnerActions(name, ownerActionIds);
 
-				String[] ownerPermissions = ownerActionIds.toArray(
-					new String[0]);
+			String[] ownerPermissions = ownerActionIds.toArray(new String[0]);
 
-				setOwnerResourcePermissions(
+			setOwnerResourcePermissions(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				ownerRole.getRoleId(), userId, ownerPermissions);
+
+			for (String roleName : modelPermissions.getRoleNames()) {
+				Role role = getRole(companyId, groupId, roleName);
+
+				setResourcePermissions(
 					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-					primKey, ownerRole.getRoleId(), userId, ownerPermissions);
-
-				for (String roleName : modelPermissions.getRoleNames()) {
-					Role role = getRole(companyId, groupId, roleName);
-
-					setResourcePermissions(
-						companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-						primKey, role.getRoleId(),
-						modelPermissions.getActionIds(roleName));
-				}
+					primKey, role.getRoleId(),
+					modelPermissions.getActionIds(roleName));
+			}
 		}
 		finally {
 			PermissionThreadLocal.setFlushResourcePermissionEnabled(
@@ -1900,86 +1899,6 @@ public class ResourcePermissionLocalServiceImpl
 		}
 	}
 
-	private boolean _matches(
-		ModelPermissions modelPermissions, String resourcePermissionName) {
-
-		if ((modelPermissions == null) ||
-			ModelPermissions.RESOURCE_NAME_UNINITIALIZED.equals(
-				modelPermissions.getResourceName())) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					new Exception(
-						"Uninitialized model permissions used for " +
-							resourcePermissionName));
-			}
-
-			return false;
-		}
-
-		if (ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE.equals(
-					modelPermissions.getResourceName())) {
-
-			if (!modelPermissions.isUsed()) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						new Exception(
-							"First model permissions used for " +
-								resourcePermissionName));
-				}
-
-				return true;
-			}
-			else {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						new Exception(
-							"First model permissions already used for " +
-								resourcePermissionName));
-				}
-
-				return false;
-			}
-		}
-
-		if (ModelPermissions.RESOURCE_NAME_ALL_RESOURCES.equals(
-					modelPermissions.getResourceName())) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					new Exception(
-						"Model permissions for all resources used for " +
-							resourcePermissionName));
-			}
-
-			return true;
-		}
-
-		if (resourcePermissionName.equals(
-					modelPermissions.getResourceName())) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					new Exception(
-						"Correct model permissions used for " +
-							resourcePermissionName));
-			}
-
-			return true;
-		}
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				new Exception(
-					StringBundler.concat(
-						"Incorrect resource name ",
-						modelPermissions.getResourceName(), " used for ",
-						resourcePermissionName)));
-		}
-
-		return false;
-	}
-
 	private Map<Long, ResourcePermission> _getResourcePermissionsMap(
 		List<ResourcePermission> resourcePermissions) {
 
@@ -2057,6 +1976,83 @@ public class ResourcePermissionLocalServiceImpl
 				IndexWriterHelperUtil.updatePermissionFields(name, name);
 			}
 		}
+	}
+
+	private boolean _matches(
+		ModelPermissions modelPermissions, String resourcePermissionName) {
+
+		if ((modelPermissions == null) ||
+			ModelPermissions.RESOURCE_NAME_UNINITIALIZED.equals(
+				modelPermissions.getResourceName())) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					new Exception(
+						"Uninitialized model permissions used for " +
+							resourcePermissionName));
+			}
+
+			return false;
+		}
+
+		if (ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE.equals(
+				modelPermissions.getResourceName())) {
+
+			if (!modelPermissions.isUsed()) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						new Exception(
+							"First model permissions used for " +
+								resourcePermissionName));
+				}
+
+				return true;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					new Exception(
+						"First model permissions already used for " +
+							resourcePermissionName));
+			}
+
+			return false;
+		}
+
+		if (ModelPermissions.RESOURCE_NAME_ALL_RESOURCES.equals(
+				modelPermissions.getResourceName())) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					new Exception(
+						"Model permissions for all resources used for " +
+							resourcePermissionName));
+			}
+
+			return true;
+		}
+
+		if (resourcePermissionName.equals(modelPermissions.getResourceName())) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					new Exception(
+						"Correct model permissions used for " +
+							resourcePermissionName));
+			}
+
+			return true;
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				new Exception(
+					StringBundler.concat(
+						"Incorrect resource name ",
+						modelPermissions.getResourceName(), " used for ",
+						resourcePermissionName)));
+		}
+
+		return false;
 	}
 
 	private boolean _updateResourcePermission(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -147,21 +147,14 @@ public class ResourcePermissionLocalServiceImpl
 			return;
 		}
 
-		boolean addModelPermissions = true;
-
 		if (!_matches(modelPermissions, name)) {
 			modelPermissions = ModelPermissionsFactory.create(name);
 
 			modelPermissions.addRolePermissions(
 				RoleConstants.OWNER, new String[0]);
 		}
-		else {
-			modelPermissions.setUsed(true);
-		}
 
-		// Unless model permissions are used insecurely we add Owner permissions
-
-		boolean addOwnerPermissions = true;
+		modelPermissions.setUsed(true);
 
 		// Individual Permissions
 
@@ -176,7 +169,6 @@ public class ResourcePermissionLocalServiceImpl
 
 			// Owner permissions
 
-			if (addOwnerPermissions) {
 				Role ownerRole = roleLocalService.getRole(
 					companyId, RoleConstants.OWNER);
 
@@ -191,9 +183,7 @@ public class ResourcePermissionLocalServiceImpl
 				setOwnerResourcePermissions(
 					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
 					primKey, ownerRole.getRoleId(), userId, ownerPermissions);
-			}
 
-			if (addModelPermissions) {
 				for (String roleName : modelPermissions.getRoleNames()) {
 					Role role = getRole(companyId, groupId, roleName);
 
@@ -202,7 +192,6 @@ public class ResourcePermissionLocalServiceImpl
 						primKey, role.getRoleId(),
 						modelPermissions.getActionIds(roleName));
 				}
-			}
 		}
 		finally {
 			PermissionThreadLocal.setFlushResourcePermissionEnabled(
@@ -1627,9 +1616,8 @@ public class ResourcePermissionLocalServiceImpl
 		if (!_matches(modelPermissions, name)) {
 			return;
 		}
-		else {
-			modelPermissions.setUsed(true);
-		}
+
+		modelPermissions.setUsed(true);
 
 		for (String roleName : modelPermissions.getRoleNames()) {
 			Role role = getRole(companyId, groupId, roleName);

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -149,6 +149,7 @@ public class ResourcePermissionLocalServiceImpl
 
 		if (!_checkModelPermissionsMatches(modelPermissions, name)) {
 			modelPermissions = ModelPermissionsFactory.create(name);
+
 			modelPermissions.addRolePermissions(
 				RoleConstants.OWNER, new String[0]);
 		}
@@ -1904,18 +1905,11 @@ public class ResourcePermissionLocalServiceImpl
 	}
 
 	private boolean _checkModelPermissionsMatches(
-			ModelPermissions modelPermissions, String resourcePermissionName)
-		throws PortalException {
-
-		boolean addOwnerPermissions = false;
-		boolean addModelPermissions = false;
+		ModelPermissions modelPermissions, String resourcePermissionName) {
 
 		if ((modelPermissions == null) ||
 			ModelPermissions.RESOURCE_NAME_UNINITIALIZED.equals(
 				modelPermissions.getResourceName())) {
-
-			addOwnerPermissions = true;
-			addModelPermissions = false;
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(
@@ -1923,14 +1917,14 @@ public class ResourcePermissionLocalServiceImpl
 						"Uninitialized model permissions used for " +
 							resourcePermissionName));
 			}
+
+			return false;
 		}
-		else if (ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE.equals(
+
+		if (ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE.equals(
 					modelPermissions.getResourceName())) {
 
 			if (!modelPermissions.isUsed()) {
-				addOwnerPermissions = true;
-				addModelPermissions = true;
-
 				modelPermissions.setUsed(true);
 
 				if (_log.isDebugEnabled()) {
@@ -1939,24 +1933,23 @@ public class ResourcePermissionLocalServiceImpl
 							"First model permissions used for " +
 								resourcePermissionName));
 				}
+
+				return true;
 			}
 			else {
-				addOwnerPermissions = false;
-				addModelPermissions = false;
-
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						new Exception(
 							"First model permissions already used for " +
 								resourcePermissionName));
 				}
+
+				return false;
 			}
 		}
-		else if (ModelPermissions.RESOURCE_NAME_ALL_RESOURCES.equals(
-					modelPermissions.getResourceName())) {
 
-			addOwnerPermissions = true;
-			addModelPermissions = true;
+		if (ModelPermissions.RESOURCE_NAME_ALL_RESOURCES.equals(
+					modelPermissions.getResourceName())) {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(
@@ -1964,12 +1957,12 @@ public class ResourcePermissionLocalServiceImpl
 						"Model permissions for all resources used for " +
 							resourcePermissionName));
 			}
-		}
-		else if (resourcePermissionName.equals(
-					modelPermissions.getResourceName())) {
 
-			addOwnerPermissions = true;
-			addModelPermissions = true;
+			return true;
+		}
+
+		if (resourcePermissionName.equals(
+					modelPermissions.getResourceName())) {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(
@@ -1977,22 +1970,20 @@ public class ResourcePermissionLocalServiceImpl
 						"Correct model permissions used for " +
 							resourcePermissionName));
 			}
-		}
-		else {
-			addOwnerPermissions = false;
-			addModelPermissions = false;
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					new Exception(
-						StringBundler.concat(
-							"Incorrect resource name ",
-							modelPermissions.getResourceName(), " used for ",
-							resourcePermissionName)));
-			}
+			return true;
 		}
 
-		return addModelPermissions;
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				new Exception(
+					StringBundler.concat(
+						"Incorrect resource name ",
+						modelPermissions.getResourceName(), " used for ",
+						resourcePermissionName)));
+		}
+
+		return false;
 	}
 
 	private Map<Long, ResourcePermission> _getResourcePermissionsMap(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -169,20 +169,20 @@ public class ResourcePermissionLocalServiceImpl
 			// Owner permissions
 
 			if (addOwnerPermissions) {
-			Role ownerRole = roleLocalService.getRole(
-				companyId, RoleConstants.OWNER);
+				Role ownerRole = roleLocalService.getRole(
+					companyId, RoleConstants.OWNER);
 
-			List<String> ownerActionIds =
-				ResourceActionsUtil.getModelResourceActions(name);
+				List<String> ownerActionIds =
+					ResourceActionsUtil.getModelResourceActions(name);
 
-			filterOwnerActions(name, ownerActionIds);
+				filterOwnerActions(name, ownerActionIds);
 
-			String[] ownerPermissions = ownerActionIds.toArray(new String[0]);
+				String[] ownerPermissions = ownerActionIds.toArray(
+					new String[0]);
 
-			setOwnerResourcePermissions(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				ownerRole.getRoleId(), userId, ownerPermissions);
-
+				setOwnerResourcePermissions(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
+					primKey, ownerRole.getRoleId(), userId, ownerPermissions);
 			}
 
 			if (addModelPermissions) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1976,7 +1976,7 @@ public class ResourcePermissionLocalServiceImpl
 
 		String resourceName = modelPermissions.getResourceName();
 
-		if (resourceName.equals(_RESOURCE_NAME_ALL_RESOURCES) ||
+		if (resourceName.equals(ModelPermissions.RESOURCE_NAME_ALL_RESOURCES) ||
 			resourceName.equals(resourcePermissionName)) {
 
 			return true;
@@ -2104,9 +2104,6 @@ public class ResourcePermissionLocalServiceImpl
 	private static final String _FIND_MISSING_RESOURCE_PERMISSIONS =
 		ResourcePermissionLocalServiceImpl.class.getName() +
 			".findMissingResourcePermissions";
-
-	private static final String _RESOURCE_NAME_ALL_RESOURCES =
-		ModelPermissions.class.getName() + "#ALL_RESOURCES";
 
 	private static final String _UPDATE_ACTION_IDS =
 		ResourcePermissionLocalServiceImpl.class.getName() + ".updateActionIds";

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -100,7 +100,7 @@ public class ResourcePermissionLocalServiceImpl
 			serviceContext.getModelPermissions();
 
 		if (_matches(modelPermissions, auditedModel.getModelClassName())) {
-			modelPermissions.setUsed(true);
+			ModelPermissionsImpl.setUsed(modelPermissions);
 
 			addModelResourcePermissions(
 				auditedModel.getCompanyId(), getGroupId(auditedModel),
@@ -155,7 +155,7 @@ public class ResourcePermissionLocalServiceImpl
 				RoleConstants.OWNER, new String[0]);
 		}
 
-		modelPermissions.setUsed(true);
+		ModelPermissionsImpl.setUsed(modelPermissions);
 
 		// Individual Permissions
 
@@ -1617,7 +1617,7 @@ public class ResourcePermissionLocalServiceImpl
 			return;
 		}
 
-		modelPermissions.setUsed(true);
+		ModelPermissionsImpl.setUsed(modelPermissions);
 
 		for (String roleName : modelPermissions.getRoleNames()) {
 			Role role = getRole(companyId, groupId, roleName);
@@ -1996,7 +1996,7 @@ public class ResourcePermissionLocalServiceImpl
 		if (ModelPermissionsImpl.RESOURCE_NAME_FIRST_RESOURCE.equals(
 				modelPermissions.getResourceName())) {
 
-			if (!modelPermissions.isUsed()) {
+			if (!ModelPermissionsImpl.isUsed(modelPermissions)) {
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						new Exception(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -99,6 +99,8 @@ public class ResourcePermissionLocalServiceImpl
 			serviceContext.getModelPermissions();
 
 		if (_matches(modelPermissions, auditedModel.getModelClassName())) {
+			modelPermissions.setUsed(true);
+
 			addModelResourcePermissions(
 				auditedModel.getCompanyId(), getGroupId(auditedModel),
 				auditedModel.getUserId(), auditedModel.getModelClassName(),
@@ -147,11 +149,14 @@ public class ResourcePermissionLocalServiceImpl
 
 		boolean addModelPermissions = true;
 
-		if (!_checkModelPermissionsMatches(modelPermissions, name)) {
+		if (!_matches(modelPermissions, name)) {
 			modelPermissions = ModelPermissionsFactory.create(name);
 
 			modelPermissions.addRolePermissions(
 				RoleConstants.OWNER, new String[0]);
+		}
+		else {
+			modelPermissions.setUsed(true);
 		}
 
 		// Unless model permissions are used insecurely we add Owner permissions
@@ -1619,8 +1624,11 @@ public class ResourcePermissionLocalServiceImpl
 			ModelPermissions modelPermissions)
 		throws PortalException {
 
-		if (!_checkModelPermissionsMatches(modelPermissions, name)) {
+		if (!_matches(modelPermissions, name)) {
 			return;
+		}
+		else {
+			modelPermissions.setUsed(true);
 		}
 
 		for (String roleName : modelPermissions.getRoleNames()) {
@@ -1904,7 +1912,7 @@ public class ResourcePermissionLocalServiceImpl
 		}
 	}
 
-	private boolean _checkModelPermissionsMatches(
+	private boolean _matches(
 		ModelPermissions modelPermissions, String resourcePermissionName) {
 
 		if ((modelPermissions == null) ||
@@ -1925,8 +1933,6 @@ public class ResourcePermissionLocalServiceImpl
 					modelPermissions.getResourceName())) {
 
 			if (!modelPermissions.isUsed()) {
-				modelPermissions.setUsed(true);
-
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						new Exception(
@@ -2063,30 +2069,6 @@ public class ResourcePermissionLocalServiceImpl
 				IndexWriterHelperUtil.updatePermissionFields(name, name);
 			}
 		}
-	}
-
-	private boolean _matches(
-		ModelPermissions modelPermissions, String resourcePermissionName) {
-
-		if (modelPermissions == null) {
-			return false;
-		}
-
-		String resourceName = modelPermissions.getResourceName();
-
-		if (resourceName.equals(
-				ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE)) {
-
-			return !modelPermissions.isUsed();
-		}
-
-		if (resourceName.equals(ModelPermissions.RESOURCE_NAME_ALL_RESOURCES) ||
-			resourceName.equals(resourcePermissionName)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private boolean _updateResourcePermission(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -148,7 +148,9 @@ public class ResourcePermissionLocalServiceImpl
 		boolean addModelPermissions = true;
 
 		if (!_checkModelPermissionsMatches(modelPermissions, name)) {
-			addModelPermissions = false;
+			modelPermissions = ModelPermissionsFactory.create(name);
+			modelPermissions.addRolePermissions(
+				RoleConstants.OWNER, new String[0]);
 		}
 
 		// Unless model permissions are used insecurely we add Owner permissions
@@ -1988,15 +1990,6 @@ public class ResourcePermissionLocalServiceImpl
 							modelPermissions.getResourceName(), " used for ",
 							resourcePermissionName)));
 			}
-		}
-
-		if (!addOwnerPermissions && !addModelPermissions) {
-			throw new PortalException(
-				StringBundler.concat(
-					"Insecure use or reuse of model permissions of ",
-					modelPermissions.getResourceName(),
-					". Please initialize it correctly or again for ",
-					resourcePermissionName));
 		}
 
 		return addModelPermissions;

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7059,10 +7059,10 @@
         com.liferay.portal.kernel.cal.DayAndPosition,\
         com.liferay.portal.kernel.cal.Duration,\
         com.liferay.portal.kernel.cal.TZSRecurrence,\
+        com.liferay.portal.kernel.internal.service.permission.ModelPermissionsImpl,\
         com.liferay.portal.kernel.messaging.Message,\
         com.liferay.portal.kernel.model.PortletPreferencesIds,\
         com.liferay.portal.kernel.security.auth.HttpPrincipal,\
-        com.liferay.portal.kernel.service.permission.ModelPermissions,\
         com.liferay.portal.kernel.service.ServiceContext,\
         com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender,\
         com.liferay.portal.kernel.util.LongWrapper,\

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.2.0
+Bundle-Version: 9.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.internal.service.permission;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Preston Crary
+ */
+public class ModelPermissionsImpl implements ModelPermissions {
+
+	public static final String RESOURCE_NAME_ALL_RESOURCES =
+		ModelPermissions.class.getName() + "#ALL_RESOURCES";
+
+	public static final String RESOURCE_NAME_FIRST_RESOURCE =
+		ModelPermissions.class.getName() + "#FIRST_RESOURCE";
+
+	public static final String RESOURCE_NAME_UNINITIALIZED =
+		ModelPermissions.class.getName() + "#UNINITIALIZED";
+
+	public ModelPermissionsImpl(String resourceName) {
+		setResourceName(resourceName);
+	}
+
+	@Override
+	public void addRolePermissions(String roleName, String... actionIds) {
+		if (ArrayUtil.isEmpty(actionIds)) {
+			return;
+		}
+
+		Set<String> actionIdSet = _actionIdsMap.get(roleName);
+
+		if (actionIdSet == null) {
+			actionIdSet = new HashSet<>();
+
+			_actionIdsMap.put(roleName, actionIdSet);
+		}
+
+		Collections.addAll(actionIdSet, actionIds);
+	}
+
+	@Override
+	public ModelPermissions clone() {
+		return new ModelPermissionsImpl(_actionIdsMap, _resourceName, _used);
+	}
+
+	@Override
+	public String[] getActionIds(String roleName) {
+		Set<String> actionIds = _actionIdsMap.get(roleName);
+
+		if (actionIds == null) {
+			return StringPool.EMPTY_ARRAY;
+		}
+
+		return actionIds.toArray(new String[0]);
+	}
+
+	@Override
+	public String getResourceName() {
+		return _resourceName;
+	}
+
+	@Override
+	public Collection<String> getRoleNames() {
+		return _actionIdsMap.keySet();
+	}
+
+	@Override
+	public boolean isUsed() {
+		return _used;
+	}
+
+	@Override
+	public void setResourceName(String resourceName) {
+		_resourceName = Objects.requireNonNull(resourceName);
+	}
+
+	@Override
+	public void setUsed(boolean used) {
+		_used = used;
+	}
+
+	private ModelPermissionsImpl(
+		Map<String, Set<String>> actionIdsMap, String resourceName,
+		boolean used) {
+
+		_actionIdsMap.putAll(actionIdsMap);
+		_resourceName = Objects.requireNonNull(resourceName);
+		_used = used;
+	}
+
+	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
+	private String _resourceName = RESOURCE_NAME_UNINITIALIZED;
+	private boolean _used;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
@@ -40,6 +40,26 @@ public class ModelPermissionsImpl implements ModelPermissions {
 	public static final String RESOURCE_NAME_UNINITIALIZED =
 		ModelPermissions.class.getName() + "#UNINITIALIZED";
 
+	public static boolean isUsed(ModelPermissions modelPermissions) {
+		if (modelPermissions instanceof ModelPermissionsImpl) {
+			ModelPermissionsImpl modelPermissionsImpl =
+				(ModelPermissionsImpl)modelPermissions;
+
+			return modelPermissionsImpl._used;
+		}
+
+		return false;
+	}
+
+	public static void setUsed(ModelPermissions modelPermissions) {
+		if (modelPermissions instanceof ModelPermissionsImpl) {
+			ModelPermissionsImpl modelPermissionsImpl =
+				(ModelPermissionsImpl)modelPermissions;
+
+			modelPermissionsImpl._used = true;
+		}
+	}
+
 	public ModelPermissionsImpl(String resourceName) {
 		setResourceName(resourceName);
 	}
@@ -88,18 +108,8 @@ public class ModelPermissionsImpl implements ModelPermissions {
 	}
 
 	@Override
-	public boolean isUsed() {
-		return _used;
-	}
-
-	@Override
 	public void setResourceName(String resourceName) {
 		_resourceName = Objects.requireNonNull(resourceName);
-	}
-
-	@Override
-	public void setUsed(boolean used) {
-		_used = used;
 	}
 
 	private ModelPermissionsImpl(

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/permission/ModelPermissionsImpl.java
@@ -60,6 +60,9 @@ public class ModelPermissionsImpl implements ModelPermissions {
 		}
 	}
 
+	public ModelPermissionsImpl() {
+	}
+
 	public ModelPermissionsImpl(String resourceName) {
 		setResourceName(resourceName);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
@@ -125,8 +125,7 @@ public class ServiceContext implements Cloneable, Serializable {
 		serviceContext.setLayoutURL(getLayoutURL());
 
 		if (_modelPermissions != null) {
-			serviceContext.setModelPermissions(
-				(ModelPermissions)_modelPermissions.clone());
+			serviceContext.setModelPermissions(_modelPermissions.clone());
 		}
 
 		serviceContext.setModifiedDate(getModifiedDate());

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
@@ -209,11 +209,7 @@ public class ServiceContext implements Cloneable, Serializable {
 		String[] groupPermissions = groupPermissionsList.toArray(new String[0]);
 		String[] guestPermissions = guestPermissionsList.toArray(new String[0]);
 
-		ModelPermissions modelPermissions = getModelPermissions();
-
-		if (modelPermissions == null) {
-			modelPermissions = new ModelPermissions(modelName);
-		}
+		ModelPermissions modelPermissions = new ModelPermissions(modelName);
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, groupPermissions);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -206,17 +207,10 @@ public class ServiceContext implements Cloneable, Serializable {
 			}
 		}
 
-		String[] groupPermissions = groupPermissionsList.toArray(new String[0]);
-		String[] guestPermissions = guestPermissionsList.toArray(new String[0]);
-
-		ModelPermissions modelPermissions = new ModelPermissions(modelName);
-
-		modelPermissions.addRolePermissions(
-			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, groupPermissions);
-		modelPermissions.addRolePermissions(
-			RoleConstants.GUEST, guestPermissions);
-
-		setModelPermissions(modelPermissions);
+		setModelPermissions(
+			ModelPermissionsFactory.create(
+				groupPermissionsList.toArray(new String[0]),
+				guestPermissionsList.toArray(new String[0]), modelName));
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
@@ -142,7 +143,8 @@ public class ServiceContextFactory {
 
 		if (serviceContext.getModelPermissions() == null) {
 			serviceContext.setModelPermissions(
-				ModelPermissionsFactory.create());
+				ModelPermissionsFactory.create(
+					ModelPermissions.RESOURCE_NAME_UNINITIALIZED));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
@@ -81,14 +81,22 @@ public class ServiceContextFactory {
 
 		ServiceContext serviceContext = _getInstance(httpServletRequest);
 
+		if (className == null) {
+			return serviceContext;
+		}
+
 		// Permissions
 
 		if (serviceContext.getModelPermissions() == null) {
 			serviceContext.setModelPermissions(
 				ModelPermissionsFactory.create(httpServletRequest, className));
 		}
+		else {
+			ModelPermissions modelPermissions =
+				serviceContext.getModelPermissions();
 
-		_ensureValidModelPermissions(serviceContext);
+			modelPermissions.setResourceName(className);
+		}
 
 		// Expando
 
@@ -109,14 +117,22 @@ public class ServiceContextFactory {
 
 		ServiceContext serviceContext = _getInstance(portletRequest);
 
+		if (className == null) {
+			return serviceContext;
+		}
+
 		// Permissions
 
 		if (serviceContext.getModelPermissions() == null) {
 			serviceContext.setModelPermissions(
 				ModelPermissionsFactory.create(portletRequest, className));
 		}
+		else {
+			ModelPermissions modelPermissions =
+				serviceContext.getModelPermissions();
 
-		_ensureValidModelPermissions(serviceContext);
+			modelPermissions.setResourceName(className);
+		}
 
 		// Expando
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
@@ -142,7 +141,8 @@ public class ServiceContextFactory {
 		ServiceContext serviceContext) {
 
 		if (serviceContext.getModelPermissions() == null) {
-			serviceContext.setModelPermissions(new ModelPermissions());
+			serviceContext.setModelPermissions(
+				ModelPermissionsFactory.create());
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.service;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.internal.service.permission.ModelPermissionsImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -160,7 +161,7 @@ public class ServiceContextFactory {
 		if (serviceContext.getModelPermissions() == null) {
 			serviceContext.setModelPermissions(
 				ModelPermissionsFactory.create(
-					ModelPermissions.RESOURCE_NAME_UNINITIALIZED));
+					ModelPermissionsImpl.RESOURCE_NAME_UNINITIALIZED));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -16,7 +16,6 @@ package com.liferay.portal.kernel.service.permission;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import java.io.Serializable;
 
@@ -24,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -42,13 +40,6 @@ public class ModelPermissions implements Cloneable, Serializable {
 
 	public static final String RESOURCE_NAME_UNINITIALIZED =
 		ModelPermissions.class.getName() + "#UNINITIALIZED";
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public ModelPermissions() {
-	}
 
 	public ModelPermissions(String resourceName) {
 		setResourceName(resourceName);
@@ -85,48 +76,12 @@ public class ModelPermissions implements Cloneable, Serializable {
 		return actionIds.toArray(new String[0]);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public List<String> getActionIdsList(String roleName) {
-		Set<String> actionIds = _actionIdsMap.get(roleName);
-
-		return ListUtil.fromCollection(actionIds);
-	}
-
 	public String getResourceName() {
 		return _resourceName;
 	}
 
 	public Collection<String> getRoleNames() {
 		return _actionIdsMap.keySet();
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public Collection<String> getRoleNames(String actionId) {
-		Set<String> roleNames = new HashSet<>();
-
-		for (Map.Entry<String, Set<String>> entry : _actionIdsMap.entrySet()) {
-			Set<String> actionIds = entry.getValue();
-
-			if (actionIds.contains(actionId)) {
-				roleNames.add(entry.getKey());
-			}
-		}
-
-		return roleNames;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public boolean isEmpty() {
-		return _actionIdsMap.isEmpty();
 	}
 
 	public boolean isUsed() {
@@ -139,40 +94,6 @@ public class ModelPermissions implements Cloneable, Serializable {
 
 	public void setUsed(boolean used) {
 		_used = used;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	protected ModelPermissions(
-		Map<String, Set<String>> roleNamesMap,
-		Map<String, Set<String>> actionIdsMap) {
-
-		this(actionIdsMap, RESOURCE_NAME_UNINITIALIZED, false);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	protected ModelPermissions(
-		Map<String, Set<String>> roleNamesMap,
-		Map<String, Set<String>> actionIdsMap, String resourceName) {
-
-		this(actionIdsMap, resourceName, false);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	protected ModelPermissions(
-		Map<String, Set<String>> roleNamesMap,
-		Map<String, Set<String>> actionIdsMap, String resourceName,
-		boolean used) {
-
-		this(actionIdsMap, resourceName, used);
 	}
 
 	private ModelPermissions(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -35,6 +35,9 @@ public class ModelPermissions implements Cloneable, Serializable {
 	public static final String RESOURCE_NAME_ALL_RESOURCES =
 		ModelPermissions.class.getName() + "#ALL_RESOURCES";
 
+	public static final String RESOURCE_NAME_FIRST_RESOURCE =
+		ModelPermissions.class.getName() + "#FIRST_RESOURCE";
+
 	public static final String RESOURCE_NAME_UNINITIALIZED =
 		ModelPermissions.class.getName() + "#UNINITIALIZED";
 
@@ -85,7 +88,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 	public Object clone() {
 		return new ModelPermissions(
 			new HashMap<>(_roleNamesMap), new HashMap<>(_actionIdsMap),
-			_resourceName);
+			_resourceName, _used);
 	}
 
 	public String[] getActionIds(String roleName) {
@@ -126,11 +129,16 @@ public class ModelPermissions implements Cloneable, Serializable {
 		return _actionIdsMap.isEmpty();
 	}
 
+	public boolean isUsed() {
+		return _used;
+	}
+
 	public void setResourceName(String resourceName) {
 		_resourceName = Objects.requireNonNull(resourceName);
 	}
 
-		_resourceName = resourceName;
+	public void setUsed(boolean used) {
+		_used = used;
 	}
 
 	protected ModelPermissions(
@@ -147,10 +155,23 @@ public class ModelPermissions implements Cloneable, Serializable {
 		_roleNamesMap.putAll(roleNamesMap);
 		_actionIdsMap.putAll(actionIdsMap);
 		_resourceName = Objects.requireNonNull(resourceName);
+		_used = false;
+	}
+
+	protected ModelPermissions(
+		Map<String, Set<String>> roleNamesMap,
+		Map<String, Set<String>> actionIdsMap, String resourceName,
+		boolean used) {
+
+		_roleNamesMap.putAll(roleNamesMap);
+		_actionIdsMap.putAll(actionIdsMap);
+		_resourceName = Objects.requireNonNull(resourceName);
+		_used = used;
 	}
 
 	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
 	private String _resourceName = RESOURCE_NAME_UNINITIALIZED;
 	private final Map<String, Set<String>> _roleNamesMap = new HashMap<>();
+	private boolean _used;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -141,6 +141,10 @@ public class ModelPermissions implements Cloneable, Serializable {
 		_used = used;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	protected ModelPermissions(
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap) {
@@ -148,6 +152,10 @@ public class ModelPermissions implements Cloneable, Serializable {
 		this(roleNamesMap, actionIdsMap, RESOURCE_NAME_UNINITIALIZED);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	protected ModelPermissions(
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap, String resourceName) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -101,6 +101,10 @@ public class ModelPermissions implements Cloneable, Serializable {
 		return actionIds.toArray(new String[0]);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public List<String> getActionIdsList(String roleName) {
 		Set<String> actionIds = _actionIdsMap.get(roleName);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -32,6 +32,10 @@ import java.util.Set;
  */
 public class ModelPermissions implements Cloneable, Serializable {
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public ModelPermissions() {
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -15,11 +15,13 @@
 package com.liferay.portal.kernel.service.permission;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.io.Serializable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,26 +54,20 @@ public class ModelPermissions implements Cloneable, Serializable {
 		setResourceName(resourceName);
 	}
 
-	public void addRolePermissions(String roleName, String actionId) {
-		Set<String> actionIds = _actionIdsMap.get(roleName);
-
-		if (actionIds == null) {
-			actionIds = new HashSet<>();
-
-			_actionIdsMap.put(roleName, actionIds);
-		}
-
-		actionIds.add(actionId);
-	}
-
-	public void addRolePermissions(String roleName, String[] actionIds) {
-		if (actionIds == null) {
+	public void addRolePermissions(String roleName, String... actionIds) {
+		if (ArrayUtil.isEmpty(actionIds)) {
 			return;
 		}
 
-		for (String actionId : actionIds) {
-			addRolePermissions(roleName, actionId);
+		Set<String> actionIdSet = _actionIdsMap.get(roleName);
+
+		if (actionIdSet == null) {
+			actionIdSet = new HashSet<>();
+
+			_actionIdsMap.put(roleName, actionIdSet);
 		}
+
+		Collections.addAll(actionIdSet, actionIds);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -32,6 +32,9 @@ import java.util.Set;
  */
 public class ModelPermissions implements Cloneable, Serializable {
 
+	public static final String RESOURCE_NAME_ALL_RESOURCES =
+		ModelPermissions.class.getName() + "#ALL_RESOURCES";
+
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
@@ -143,9 +146,6 @@ public class ModelPermissions implements Cloneable, Serializable {
 		_actionIdsMap.putAll(actionIdsMap);
 		_resourceName = Objects.requireNonNull(resourceName);
 	}
-
-	private static final String _RESOURCE_NAME_ALL_RESOURCES =
-		ModelPermissions.class.getName() + "#ALL_RESOURCES";
 
 	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
 	private String _resourceName = _RESOURCE_NAME_ALL_RESOURCES;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -126,6 +126,10 @@ public class ModelPermissions implements Cloneable, Serializable {
 		return roleNames;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public boolean isEmpty() {
 		return _actionIdsMap.isEmpty();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -36,10 +36,6 @@ public interface ModelPermissions extends Cloneable, Serializable {
 
 	public Collection<String> getRoleNames();
 
-	public boolean isUsed();
-
 	public void setResourceName(String resourceName);
-
-	public void setUsed(boolean used);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -76,8 +76,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 
 	@Override
 	public Object clone() {
-		return new ModelPermissions(
-			new HashMap<>(_actionIdsMap), _resourceName, _used);
+		return new ModelPermissions(_actionIdsMap, _resourceName, _used);
 	}
 
 	public String[] getActionIds(String roleName) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -53,16 +53,6 @@ public class ModelPermissions implements Cloneable, Serializable {
 	}
 
 	public void addRolePermissions(String roleName, String actionId) {
-		Set<String> roleNames = _roleNamesMap.get(actionId);
-
-		if (roleNames == null) {
-			roleNames = new HashSet<>();
-
-			_roleNamesMap.put(actionId, roleNames);
-		}
-
-		roleNames.add(roleName);
-
 		Set<String> actionIds = _actionIdsMap.get(roleName);
 
 		if (actionIds == null) {
@@ -87,8 +77,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 	@Override
 	public Object clone() {
 		return new ModelPermissions(
-			new HashMap<>(_roleNamesMap), new HashMap<>(_actionIdsMap),
-			_resourceName, _used);
+			new HashMap<>(_actionIdsMap), _resourceName, _used);
 	}
 
 	public String[] getActionIds(String roleName) {
@@ -119,11 +108,19 @@ public class ModelPermissions implements Cloneable, Serializable {
 		return _actionIdsMap.keySet();
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public Collection<String> getRoleNames(String actionId) {
-		Set<String> roleNames = _roleNamesMap.get(actionId);
+		Set<String> roleNames = new HashSet<>();
 
-		if (roleNames == null) {
-			roleNames = new HashSet<>();
+		for (Map.Entry<String, Set<String>> entry : _actionIdsMap.entrySet()) {
+			Set<String> actionIds = entry.getValue();
+
+			if (actionIds.contains(actionId)) {
+				roleNames.add(entry.getKey());
+			}
 		}
 
 		return roleNames;
@@ -153,7 +150,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap) {
 
-		this(roleNamesMap, actionIdsMap, RESOURCE_NAME_UNINITIALIZED);
+		this(actionIdsMap, RESOURCE_NAME_UNINITIALIZED, false);
 	}
 
 	/**
@@ -164,18 +161,25 @@ public class ModelPermissions implements Cloneable, Serializable {
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap, String resourceName) {
 
-		_roleNamesMap.putAll(roleNamesMap);
-		_actionIdsMap.putAll(actionIdsMap);
-		_resourceName = Objects.requireNonNull(resourceName);
-		_used = false;
+		this(actionIdsMap, resourceName, false);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	protected ModelPermissions(
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap, String resourceName,
 		boolean used) {
 
-		_roleNamesMap.putAll(roleNamesMap);
+		this(actionIdsMap, resourceName, used);
+	}
+
+	private ModelPermissions(
+		Map<String, Set<String>> actionIdsMap, String resourceName,
+		boolean used) {
+
 		_actionIdsMap.putAll(actionIdsMap);
 		_resourceName = Objects.requireNonNull(resourceName);
 		_used = used;
@@ -183,7 +187,6 @@ public class ModelPermissions implements Cloneable, Serializable {
 
 	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
 	private String _resourceName = RESOURCE_NAME_UNINITIALIZED;
-	private final Map<String, Set<String>> _roleNamesMap = new HashMap<>();
 	private boolean _used;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -35,6 +35,9 @@ public class ModelPermissions implements Cloneable, Serializable {
 	public static final String RESOURCE_NAME_ALL_RESOURCES =
 		ModelPermissions.class.getName() + "#ALL_RESOURCES";
 
+	public static final String RESOURCE_NAME_UNINITIALIZED =
+		ModelPermissions.class.getName() + "#UNINITIALIZED";
+
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
@@ -124,9 +127,8 @@ public class ModelPermissions implements Cloneable, Serializable {
 	}
 
 	public void setResourceName(String resourceName) {
-		if (resourceName == null) {
-			resourceName = _RESOURCE_NAME_ALL_RESOURCES;
-		}
+		_resourceName = Objects.requireNonNull(resourceName);
+	}
 
 		_resourceName = resourceName;
 	}
@@ -135,7 +137,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 		Map<String, Set<String>> roleNamesMap,
 		Map<String, Set<String>> actionIdsMap) {
 
-		this(roleNamesMap, actionIdsMap, _RESOURCE_NAME_ALL_RESOURCES);
+		this(roleNamesMap, actionIdsMap, RESOURCE_NAME_UNINITIALIZED);
 	}
 
 	protected ModelPermissions(
@@ -148,7 +150,7 @@ public class ModelPermissions implements Cloneable, Serializable {
 	}
 
 	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
-	private String _resourceName = _RESOURCE_NAME_ALL_RESOURCES;
+	private String _resourceName = RESOURCE_NAME_UNINITIALIZED;
 	private final Map<String, Set<String>> _roleNamesMap = new HashMap<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissions.java
@@ -14,99 +14,32 @@
 
 package com.liferay.portal.kernel.service.permission;
 
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.ArrayUtil;
-
 import java.io.Serializable;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * @author Jorge Ferrer
  */
-public class ModelPermissions implements Cloneable, Serializable {
+@ProviderType
+public interface ModelPermissions extends Cloneable, Serializable {
 
-	public static final String RESOURCE_NAME_ALL_RESOURCES =
-		ModelPermissions.class.getName() + "#ALL_RESOURCES";
+	public void addRolePermissions(String roleName, String... actionIds);
 
-	public static final String RESOURCE_NAME_FIRST_RESOURCE =
-		ModelPermissions.class.getName() + "#FIRST_RESOURCE";
+	public ModelPermissions clone();
 
-	public static final String RESOURCE_NAME_UNINITIALIZED =
-		ModelPermissions.class.getName() + "#UNINITIALIZED";
+	public String[] getActionIds(String roleName);
 
-	public ModelPermissions(String resourceName) {
-		setResourceName(resourceName);
-	}
+	public String getResourceName();
 
-	public void addRolePermissions(String roleName, String... actionIds) {
-		if (ArrayUtil.isEmpty(actionIds)) {
-			return;
-		}
+	public Collection<String> getRoleNames();
 
-		Set<String> actionIdSet = _actionIdsMap.get(roleName);
+	public boolean isUsed();
 
-		if (actionIdSet == null) {
-			actionIdSet = new HashSet<>();
+	public void setResourceName(String resourceName);
 
-			_actionIdsMap.put(roleName, actionIdSet);
-		}
-
-		Collections.addAll(actionIdSet, actionIds);
-	}
-
-	@Override
-	public Object clone() {
-		return new ModelPermissions(_actionIdsMap, _resourceName, _used);
-	}
-
-	public String[] getActionIds(String roleName) {
-		Set<String> actionIds = _actionIdsMap.get(roleName);
-
-		if (actionIds == null) {
-			return StringPool.EMPTY_ARRAY;
-		}
-
-		return actionIds.toArray(new String[0]);
-	}
-
-	public String getResourceName() {
-		return _resourceName;
-	}
-
-	public Collection<String> getRoleNames() {
-		return _actionIdsMap.keySet();
-	}
-
-	public boolean isUsed() {
-		return _used;
-	}
-
-	public void setResourceName(String resourceName) {
-		_resourceName = Objects.requireNonNull(resourceName);
-	}
-
-	public void setUsed(boolean used) {
-		_used = used;
-	}
-
-	private ModelPermissions(
-		Map<String, Set<String>> actionIdsMap, String resourceName,
-		boolean used) {
-
-		_actionIdsMap.putAll(actionIdsMap);
-		_resourceName = Objects.requireNonNull(resourceName);
-		_used = used;
-	}
-
-	private final Map<String, Set<String>> _actionIdsMap = new HashMap<>();
-	private String _resourceName = RESOURCE_NAME_UNINITIALIZED;
-	private boolean _used;
+	public void setUsed(boolean used);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -150,6 +150,10 @@ public class ModelPermissionsFactory {
 	public static ModelPermissions createWithDefaultPermissions(
 		String className) {
 
+		if (className == null) {
+			throw new NullPointerException("className is null");
+		}
+
 		ModelPermissions modelPermissions = new ModelPermissions(className);
 
 		List<String> modelResourceGroupDefaultActions =

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -40,10 +40,6 @@ public class ModelPermissionsFactory {
 
 	public static final String MODEL_PERMISSIONS_PREFIX = "modelPermissions";
 
-	public static ModelPermissions create() {
-		return new ModelPermissions(null);
-	}
-
 	public static ModelPermissions create(
 		HttpServletRequest httpServletRequest) {
 
@@ -132,6 +128,11 @@ public class ModelPermissionsFactory {
 			RoleConstants.GUEST, guestPermissions);
 
 		return modelPermissions;
+	}
+
+	public static ModelPermissions createForAllResources() {
+		return new ModelPermissions(
+			ModelPermissions.RESOURCE_NAME_ALL_RESOURCES);
 	}
 
 	public static ModelPermissions createWithDefaultPermissions(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.service.permission;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.internal.service.permission.ModelPermissionsImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Role;
@@ -68,7 +69,7 @@ public class ModelPermissionsFactory {
 		Map<String, String[]> modelPermissionsParameterMap, String className) {
 
 		if (className == null) {
-			className = ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE;
+			className = ModelPermissionsImpl.RESOURCE_NAME_FIRST_RESOURCE;
 		}
 
 		ModelPermissions modelPermissions = null;
@@ -81,7 +82,7 @@ public class ModelPermissionsFactory {
 					CompanyThreadLocal.getCompanyId(), entry.getKey());
 
 				if (modelPermissions == null) {
-					modelPermissions = new ModelPermissions(className);
+					modelPermissions = new ModelPermissionsImpl(className);
 				}
 
 				modelPermissions.addRolePermissions(
@@ -115,7 +116,7 @@ public class ModelPermissionsFactory {
 	}
 
 	public static ModelPermissions create(String className) {
-		return new ModelPermissions(className);
+		return new ModelPermissionsImpl(className);
 	}
 
 	public static ModelPermissions create(
@@ -129,10 +130,10 @@ public class ModelPermissionsFactory {
 		String className) {
 
 		if (className == null) {
-			className = ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE;
+			className = ModelPermissionsImpl.RESOURCE_NAME_FIRST_RESOURCE;
 		}
 
-		ModelPermissions modelPermissions = new ModelPermissions(className);
+		ModelPermissions modelPermissions = new ModelPermissionsImpl(className);
 
 		modelPermissions.addRolePermissions(
 			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, groupPermissions);
@@ -143,8 +144,8 @@ public class ModelPermissionsFactory {
 	}
 
 	public static ModelPermissions createForAllResources() {
-		return new ModelPermissions(
-			ModelPermissions.RESOURCE_NAME_ALL_RESOURCES);
+		return new ModelPermissionsImpl(
+			ModelPermissionsImpl.RESOURCE_NAME_ALL_RESOURCES);
 	}
 
 	public static ModelPermissions createWithDefaultPermissions(
@@ -154,7 +155,7 @@ public class ModelPermissionsFactory {
 			throw new NullPointerException("className is null");
 		}
 
-		ModelPermissions modelPermissions = new ModelPermissions(className);
+		ModelPermissions modelPermissions = new ModelPermissionsImpl(className);
 
 		List<String> modelResourceGroupDefaultActions =
 			ResourceActionsUtil.getModelResourceGroupDefaultActions(className);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -54,6 +54,10 @@ public class ModelPermissionsFactory {
 			httpServletRequest.getParameterMap(), className);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public static ModelPermissions create(
 		Map<String, String[]> modelPermissionsParameterMap) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -40,6 +40,10 @@ public class ModelPermissionsFactory {
 
 	public static final String MODEL_PERMISSIONS_PREFIX = "modelPermissions";
 
+	public static ModelPermissions create() {
+		return new ModelPermissions(null);
+	}
+
 	public static ModelPermissions create(
 		HttpServletRequest httpServletRequest) {
 
@@ -104,6 +108,10 @@ public class ModelPermissionsFactory {
 
 		return _createModelPermissions(
 			portletRequest.getParameterMap(), className);
+	}
+
+	public static ModelPermissions create(String className) {
+		return new ModelPermissions(className);
 	}
 
 	public static ModelPermissions create(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/ModelPermissionsFactory.java
@@ -63,6 +63,10 @@ public class ModelPermissionsFactory {
 	public static ModelPermissions create(
 		Map<String, String[]> modelPermissionsParameterMap, String className) {
 
+		if (className == null) {
+			className = ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE;
+		}
+
 		ModelPermissions modelPermissions = null;
 
 		for (Map.Entry<String, String[]> entry :
@@ -119,6 +123,10 @@ public class ModelPermissionsFactory {
 	public static ModelPermissions create(
 		String[] groupPermissions, String[] guestPermissions,
 		String className) {
+
+		if (className == null) {
+			className = ModelPermissions.RESOURCE_NAME_FIRST_RESOURCE;
+		}
 
 		ModelPermissions modelPermissions = new ModelPermissions(className);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.2
+version 1.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -116,9 +116,9 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 
 		Assert.assertEquals(
 			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, roleName);
-		Assert.assertEquals(
-			ListUtil.fromArray(groupPermissions),
-			modelPermissions.getActionIdsList(roleName));
+		Assert.assertArrayEquals(
+			groupPermissions,
+			modelPermissions.getActionIds(roleName));
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -119,10 +118,10 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 		Assert.assertEquals(
 			RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE, roleName);
 		Assert.assertArrayEquals(
-			groupPermissions,
-			modelPermissions.getActionIds(roleName));
+			groupPermissions, modelPermissions.getActionIds(roleName));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testCreateWithGuestAndGroupPermissions() {
 		String[] groupPermissions = {ActionKeys.VIEW};

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -31,8 +31,10 @@ import com.liferay.portal.kernel.util.ListUtil;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -122,22 +124,22 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 	}
 
 	@Test
-	public void testCreateWithGuestAndGroupPermissions() throws Exception {
+	public void testCreateWithGuestAndGroupPermissions() {
 		String[] groupPermissions = {ActionKeys.VIEW};
 		String[] guestPermissions = {ActionKeys.VIEW};
 
 		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
 			groupPermissions, guestPermissions);
 
-		Collection<String> roleNames = modelPermissions.getRoleNames();
+		Set<String> expectedRoleNames = new HashSet<>(
+			Arrays.asList(
+				RoleConstants.PLACEHOLDER_DEFAULT_GROUP_ROLE,
+				RoleConstants.GUEST));
 
-		Assert.assertEquals(roleNames.toString(), 2, roleNames.size());
-
-		Collection<String> viewActionIdRoleNames =
-			modelPermissions.getRoleNames(ActionKeys.VIEW);
+		Assert.assertEquals(expectedRoleNames, modelPermissions.getRoleNames());
 
 		Assert.assertEquals(
-			viewActionIdRoleNames.toString(), 2, viewActionIdRoleNames.size());
+			expectedRoleNames, modelPermissions.getRoleNames(ActionKeys.VIEW));
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/service/permission/ModelPermissionsFactoryTest.java
@@ -121,7 +121,6 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 			groupPermissions, modelPermissions.getActionIds(roleName));
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testCreateWithGuestAndGroupPermissions() {
 		String[] groupPermissions = {ActionKeys.VIEW};
@@ -136,9 +135,6 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 				RoleConstants.GUEST));
 
 		Assert.assertEquals(expectedRoleNames, modelPermissions.getRoleNames());
-
-		Assert.assertEquals(
-			expectedRoleNames, modelPermissions.getRoleNames(ActionKeys.VIEW));
 	}
 
 	@Test


### PR DESCRIPTION
Hi @martamedio and @topolik,

If we cannot allow a major change here we can drop off fb662c709b84ee0a8d45aa124ad5690c8dc8b642...fad4789be65753335cece3c2a1557d9bb27f5339

Main thing is we should keep the "RESOURCE_NAME_*" strings and the isUsed() / setUsed() stuff internal if we can.  That way going forward we have an easier time maintaining this stuff.

If you're okay with this you can remove off all the deprecated methods in that package since it's a major change already and consider if you want all the public methods in ModelPermissionsFactory - some of those are only used internally.

CC @brianchandotcom