### PR TITLE
LPS-117309 Fix regression in logging

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -770,35 +770,45 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 			HttpSession httpSession = originalHttpServletRequest.getSession();
 
+			httpSession.setAttribute(
+				SamlWebKeys.SAML_SUBJECT_NAME_ID, nameID.getValue());
+
+			String errorKey = StringPool.BLANK;
+
 			if (portalException instanceof ContactNameException) {
-				httpSession.setAttribute(
-					SamlWebKeys.SAML_SSO_ERROR,
-					ContactNameException.class.getSimpleName());
+				errorKey = ContactNameException.class.getSimpleName();
+			}
+			else if (portalException instanceof SubjectException) {
+				errorKey = SubjectException.class.getSimpleName();
 			}
 			else if (portalException instanceof MustNotUseCompanyMx) {
-				httpSession.setAttribute(
-					SamlWebKeys.SAML_SSO_ERROR,
-					MustNotUseCompanyMx.class.getSimpleName());
+				errorKey = MustNotUseCompanyMx.class.getSimpleName();
 			}
 			else if (portalException instanceof UserEmailAddressException) {
-				httpSession.setAttribute(
-					SamlWebKeys.SAML_SSO_ERROR,
-					UserEmailAddressException.class.getSimpleName());
+				errorKey = UserEmailAddressException.class.getSimpleName();
 			}
 			else if (portalException instanceof UserScreenNameException) {
-				httpSession.setAttribute(
-					SamlWebKeys.SAML_SSO_ERROR,
-					UserScreenNameException.class.getSimpleName());
+				errorKey = UserScreenNameException.class.getSimpleName();
 			}
 			else {
 				Class<?> clazz = portalException.getClass();
 
 				httpSession.setAttribute(
 					SamlWebKeys.SAML_SSO_ERROR, clazz.getSimpleName());
+
+				throw portalException;
 			}
 
-			httpSession.setAttribute(
-				SamlWebKeys.SAML_SUBJECT_NAME_ID, nameID.getValue());
+			httpSession.setAttribute(SamlWebKeys.SAML_SSO_ERROR, errorKey);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException, portalException);
+			}
+			else {
+				if (!(portalException instanceof SubjectException)) {
+					_log.error(portalException.getMessage());
+				}
+			}
 
 			httpServletResponse.sendRedirect(
 				getAuthRedirectURL(messageContext, httpServletRequest));

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.ContactNameException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
+import com.liferay.portal.kernel.exception.UserEmailAddressException.MustNotUseCompanyMx;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -773,6 +774,11 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 				httpSession.setAttribute(
 					SamlWebKeys.SAML_SSO_ERROR,
 					ContactNameException.class.getSimpleName());
+			}
+			else if (portalException instanceof MustNotUseCompanyMx) {
+				httpSession.setAttribute(
+					SamlWebKeys.SAML_SSO_ERROR,
+					MustNotUseCompanyMx.class.getSimpleName());
 			}
 			else if (portalException instanceof UserEmailAddressException) {
 				httpSession.setAttribute(

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/taglib/SamlBottomJSPDynamicInclude.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/taglib/SamlBottomJSPDynamicInclude.java
@@ -16,6 +16,7 @@ package com.liferay.saml.web.internal.servlet.taglib;
 
 import com.liferay.portal.kernel.exception.ContactNameException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
+import com.liferay.portal.kernel.exception.UserEmailAddressException.MustNotUseCompanyMx;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -117,6 +118,7 @@ public class SamlBottomJSPDynamicInclude extends BaseJSPDynamicInclude {
 
 	private static final String[] _ERRORS = {
 		ContactNameException.class.getSimpleName(),
+		MustNotUseCompanyMx.class.getSimpleName(),
 		PrincipalException.MustBeAuthenticated.class.getSimpleName(),
 		SubjectException.class.getSimpleName(),
 		UserEmailAddressException.class.getSimpleName(),


### PR DESCRIPTION
Following on from martamedio/liferay-portal/pull/182.

Avoids logging at error level, except when encountering likely system configuration or integration issues. For example 
* Missing SAML attribute mappings
* Portal instance is configured to disallow strangers from creating accounts with the company MX + Resolved user has company MX. This usually means some LDAP integration should have imported the user already. It could be a malicious attempt to create an account, but sys admin would likely want to be alerted to this as an ERROR also.

Other rejected stranger access is not logged unless at DEBUG level, because it is too likely this will happen and could DoS logs.